### PR TITLE
Add closing brace in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ const tree = [
 
 ```javascript
 const {generateFlatAST, generateCode} = require('flast');
-const ast = generateFlatAST(`console.log('flAST'`);
+const ast = generateFlatAST(`console.log('flAST')`);
 const reconstructedCode = generateCode(ast[0]); // rebuild from root node
 ```
 #### generateFlatAST Options


### PR DESCRIPTION
The example shown under the Usage section doesn't run 

```js
const {generateFlatAST, generateCode} = require('flast');
const ast = generateFlatAST(`console.log('flAST'`);
const reconstructedCode = generateCode(ast[0]); // rebuild from root node
```

as the closing brace is missing in the quoted string `console.log('flAST'`

This tiny PR just adds the closing brace. Nothing more.