### PR TITLE
Add ParentKey property

### DIFF
--- a/src/flast.js
+++ b/src/flast.js
@@ -21,11 +21,13 @@ const ecmaVersion = 'latest';
 const ASTNode = espreeASTNode;
 
 /**
- * @param inputCode
+ * @param {string} inputCode
+ * @param {object} opts Additional options for espree
  * @return {ASTNode} The root of the AST
  */
-function parseCode(inputCode) {
-	return parse(inputCode, {ecmaVersion, comment: true, range: true});
+function parseCode(inputCode, opts = {}) {
+	// noinspection JSValidateTypes
+	return parse(inputCode, {ecmaVersion, comment: true, range: true, ...opts});
 }
 
 /**
@@ -46,6 +48,9 @@ function getParentKey(parent, targetChildNodeId) {
 const generateFlatASTDefaultOptions = {
 	detailed: true,   // If false, include only original node without any further details
 	includeSrc: true, // If false, do not include node src. Only available when `detailed` option is true
+	parseOpts: {      // Options for the espree parser
+		sourceType: 'module',
+	},
 };
 
 /**
@@ -55,11 +60,12 @@ const generateFlatASTDefaultOptions = {
  */
 function generateFlatAST(inputCode, opts = {}) {
 	opts = { ...generateFlatASTDefaultOptions, ...opts };
-	const rootNode = parseCode(inputCode);
+	const parseOpts = opts.parseOpts || {};
+	const rootNode = parseCode(inputCode, parseOpts);
 	let scopeManager;
 	try {
 		if (opts.detailed) { // noinspection JSCheckFunctionSignatures
-			scopeManager = eslineScope.analyze(rootNode, {optimistic: true, ecmaVersion});
+			scopeManager = analyze(rootNode, {optimistic: true, ecmaVersion});
 		}
 	} catch {}
 	const tree = [];

--- a/src/flast.js
+++ b/src/flast.js
@@ -16,6 +16,21 @@ function parseCode(inputCode) {
 	return parse(inputCode, {ecmaVersion, comment: true, range: true});
 }
 
+/**
+ * Return the key the child node is assigned in the parent node if applicable; null otherwise.
+ * @param {ASTNode} parent
+ * @param {number} targetChildNodeId
+ * @returns {string|null}
+ */
+function getParentKey(parent, targetChildNodeId) {
+	if (parent) {
+		for (const key of Object.keys(parent)) {
+			if (parent[key]?.nodeId === targetChildNodeId) return key;
+		}
+	}
+	return null;
+}
+
 const generateFlatASTDefaultOptions = {
 	detailed: true,   // If false, include only original node without any further details
 	includeSrc: true, // If false, do not include node src. Only available when `detailed` option is true
@@ -49,6 +64,7 @@ function generateFlatAST(inputCode, opts = {}) {
 				if (opts.includeSrc) node.src = inputCode.substring(node.range[0], node.range[1]);
 				node.childNodes = [];
 				node.parentNode = parentNode;
+				node.parentKey = getParentKey(parentNode, node.nodeId);
 				// Set new scope when entering a function structure
 				if (scopeManager && /Function/.test(node.type)) currentScope = scopeManager.acquire(node);
 				if (currentScope && currentScope.scopeId === undefined) currentScope.scopeId = scopeId++;

--- a/src/flast.js
+++ b/src/flast.js
@@ -1,12 +1,24 @@
 // noinspection JSUnusedGlobalSymbols
 
 // eslint-disable-next-line no-unused-vars
-const {parse, ASTNode} = require('espree');
+const {parse, ASTNode:espreeASTNode} = require('espree');
 const {generate} = require('escodegen');
 const estraverse = require('estraverse');
-const eslineScope = require('eslint-scope');
+// eslint-disable-next-line no-unused-vars
+const {analyze, ScopeManager} = require('eslint-scope');
 
-const ecmaVersion = 2022;
+const ecmaVersion = 'latest';
+
+/**
+ * @typedef ASTNode
+ * @property {number} nodeId
+ * @property {string} src
+ * @property {array} childNodes
+ * @property {?ASTNode} parentNode
+ * @property {ScopeManager} scope
+ * @property {?string} parentKey
+ */
+const ASTNode = espreeASTNode;
 
 /**
  * @param inputCode

--- a/tests/testFlast.js
+++ b/tests/testFlast.js
@@ -16,9 +16,9 @@ function testNumberOfNodes() {
 		BinaryExpression: 2,
 		Literal: 3,
 	};
-	const expectedNubmerOfNodes = 11;
-	assert(ast.length === expectedNubmerOfNodes,
-		`Unexpected number of nodes: Expected ${expectedNubmerOfNodes} but got ${ast.length}`);
+	const expectedNumberOfNodes = 11;
+	assert(ast.length === expectedNumberOfNodes,
+		`Unexpected number of nodes: Expected ${expectedNumberOfNodes} but got ${ast.length}`);
 	for (const nodeType of Object.keys(expectedBreakdown)) {
 		const numberOfNodes = ast.filter(n => n.type === nodeType).length;
 		assert(numberOfNodes === expectedBreakdown[nodeType],
@@ -56,10 +56,33 @@ function testFlastOptionsDetailed() {
 		`Flat AST includes details despite 'detailed' option set to true and 'includeSrc' option set to false.`);
 }
 
+/**
+ * Verify the code breakdown generates the expected nodes by checking the properties of the generated ASTNodes.
+ */
+function testNodesStructureIntegrity() {
+	const code = `a=3`;
+	const ast = generateFlatAST(code);
+	const expectedBreakdown = [
+		{nodeId: 0, type: 'Program', start: 0, end: 3, src: 'a=3', parentNode: null, parentKey: null},
+		{nodeId: 1, type: 'ExpressionStatement', start: 0, end: 3, src: 'a=3', parentKey: null},
+		{nodeId: 2, type: 'AssignmentExpression', start: 0, end: 3, src: 'a=3', operator: '=', parentKey: 'expression'},
+		{nodeId: 3, type: 'Identifier', start: 0, end: 1, src: 'a', parentKey: 'left'},
+		{nodeId: 4, type: 'Literal', start: 2, end: 3, src: '3', value: 3, raw: '3', parentKey: 'right'},
+	];
+	expectedBreakdown.forEach(node => {
+		const parsedNode = ast[node.nodeId];
+		for (const [k, v] of Object.entries(node)) {
+			assert(parsedNode[k] === v,
+				`Value in parsed node, ${parsedNode[k]}, does not match expected value: ${v}, for key ${k}`);
+		}
+	});
+}
+
 const tests = {
 	'number of nodes': testNumberOfNodes,
 	'parse and generate': testParseAndGenerate,
 	'options: detailed': testFlastOptionsDetailed,
+	'ASTNode structure integrity': testNodesStructureIntegrity,
 };
 
 module.exports = tests;


### PR DESCRIPTION
Useful for determining the relationship between parent and child nodes.
Also in this PR:

- Added test to verify the validity of the node structure.
- Added ability to pass options to the espree parser.
- Changed default parsing mode to 'module'.
- Improved ASTNode definition.