### PR TITLE
Fix Missing Comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flast",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flast",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "escodegen": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flast",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Flatten JS AST",
   "main": "src/index.js",
   "scripts": {

--- a/src/flast.js
+++ b/src/flast.js
@@ -1,5 +1,5 @@
 const {parse} = require('espree');
-const {generate} = require('escodegen');
+const {generate, attachComments} = require('escodegen');
 const estraverse = require('estraverse');
 const {analyze} = require('eslint-scope');
 
@@ -12,7 +12,9 @@ const sourceType = 'module';
  * @return {ASTNode} The root of the AST
  */
 function parseCode(inputCode, opts = {}) {
-	return parse(inputCode, {ecmaVersion, comment: true, range: true, ...opts});
+	const rootNode = parse(inputCode, {ecmaVersion, comment: true, range: true, ...opts});
+	if (rootNode.tokens) attachComments(rootNode, rootNode.comments, rootNode.tokens);
+	return rootNode;
 }
 
 const excludedParentKeys = [
@@ -51,6 +53,8 @@ const generateFlatASTDefaultOptions = {
 	// Options for the espree parser
 	parseOpts: {
 		sourceType,
+		comment: true,
+		tokens: true,
 	},
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -11,6 +11,7 @@ const {Scope} = require('eslint-scope');
  * @property {ASTNode} [callee]
  * @property {ASTNode[]} [cases]
  * @property {ASTNode[]} [childNodes]
+ * @property {Object[]} [comments]
  * @property {boolean} [computed]
  * @property {ASTNode} [consequent]
  * @property {string} [cooked]
@@ -35,6 +36,7 @@ const {Scope} = require('eslint-scope');
  * @property {ASTNode} [key]
  * @property {string} [kind]
  * @property {ASTNode} [label]
+ * @property {Object[]} [leadingComments]
  * @property {ASTNode} [left]
  * @property {number[]} [lineage] The nodeIds of all parent nodes
  * @property {ASTNode} [local]
@@ -68,6 +70,8 @@ const {Scope} = require('eslint-scope');
  * @property {ASTNode} [superClass]
  * @property {boolean} [tail]
  * @property {ASTNode} [test]
+ * @property {ASTNode} [tokens]
+ * @property {Object[]} [trailingComments]
  * @property {ASTNode} [update]
  * @property {ASTNode|string|number|boolean} [value]
  */


### PR DESCRIPTION
As reported in REstringer [issue #87](https://github.com/PerimeterX/restringer/issues/87):
AST changes dropped all comments.
The expected behavior is to attach the comments to the replacement node, or the closest relevant node in case of deletion.