### PR TITLE
TypeMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install
 - Tracks scope and connects each declaration to its references.  
   See [eslint-scope](https://github.com/eslint/eslint-scope) for more info on the scopes used.
 - Adds a unique id to each node to simplify tracking and understanding relations between nodes.
-- Maps the types to the node ids for easier access.
+- Maps the types to the nodes for easier access.
 - <u>Arborist</u> - marks nodes for replacement or deletion and applies all changes in a single iteration over the tree.
 
 ### flAST Data Structure

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ npm install
 - Tracks scope and connects each declaration to its references.  
   See [eslint-scope](https://github.com/eslint/eslint-scope) for more info on the scopes used.
 - Adds a unique id to each node to simplify tracking and understanding relations between nodes.
+- Maps the types to the node ids for easier access.
 - <u>Arborist</u> - marks nodes for replacement or deletion and applies all changes in a single iteration over the tree.
 
 ### flAST Data Structure

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "escodegen": "npm:@javascript-obfuscator/escodegen",
-        "eslint-scope": "^8.1.0",
+        "eslint-scope": "^8.2.0",
         "espree": "^10.3.0",
         "estraverse": "^5.3.0"
       },
       "devDependencies": {
-        "eslint": "^9.12.0",
+        "eslint": "^9.14.0",
         "husky": "^9.1.6"
       }
     },
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.0.tgz",
-      "integrity": "sha512-xnRgu9DxZbkWak/te3fcytNyp8MTbuiZIaueg2rgEvBuN55n04nwLYLU9TX/VVlusc9L2ZNXi99nUFNkHXtr5g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -366,9 +366,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flast",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flast",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "escodegen": "npm:@javascript-obfuscator/escodegen",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flast",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Flatten JS AST",
   "main": "src/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   "homepage": "https://github.com/PerimeterX/flast#readme",
   "dependencies": {
     "escodegen": "npm:@javascript-obfuscator/escodegen",
-    "eslint-scope": "^8.1.0",
+    "eslint-scope": "^8.2.0",
     "espree": "^10.3.0",
     "estraverse": "^5.3.0"
   },
   "devDependencies": {
-    "eslint": "^9.12.0",
+    "eslint": "^9.14.0",
     "husky": "^9.1.6"
   }
 }

--- a/src/flast.js
+++ b/src/flast.js
@@ -19,7 +19,7 @@ function parseCode(inputCode, opts = {}) {
 
 const excludedParentKeys = [
 	'type', 'start', 'end', 'range', 'sourceType', 'comments', 'srcClosure', 'nodeId',
-	'childNodes', 'parentNode', 'parentKey', 'scope',
+	'childNodes', 'parentNode', 'parentKey', 'scope', 'typeMap', 'lineage', 'allScopes',
 ];
 
 /**
@@ -123,6 +123,7 @@ function extractNodesFromRoot(rootNode, opts) {
 	opts = { ...generateFlatASTDefaultOptions, ...opts };
 	const tree = [];
 	let nodeId = 0;
+	const typeMap = {};
 
 	// noinspection JSUnusedGlobalSymbols
 	estraverse.traverse(rootNode, {
@@ -133,6 +134,8 @@ function extractNodesFromRoot(rootNode, opts) {
 		enter(node, parentNode) {
 			tree.push(node);
 			node.nodeId = nodeId++;
+			if (!typeMap[node.type]) typeMap[node.type] = [node.nodeId];
+			else typeMap[node.type].push(node.nodeId);
 			node.childNodes = [];
 			node.parentNode = parentNode;
 			node.parentKey = parentNode ? getParentKey(node) : '';
@@ -146,6 +149,7 @@ function extractNodesFromRoot(rootNode, opts) {
 			});
 		}
 	});
+	if (tree?.length) tree[0].typeMap = typeMap;
 	return tree;
 }
 

--- a/src/flast.js
+++ b/src/flast.js
@@ -134,8 +134,8 @@ function extractNodesFromRoot(rootNode, opts) {
 		enter(node, parentNode) {
 			tree.push(node);
 			node.nodeId = nodeId++;
-			if (!typeMap[node.type]) typeMap[node.type] = [node.nodeId];
-			else typeMap[node.type].push(node.nodeId);
+			if (!typeMap[node.type]) typeMap[node.type] = [node];
+			else typeMap[node.type].push(node);
 			node.childNodes = [];
 			node.parentNode = parentNode;
 			node.parentKey = parentNode ? getParentKey(node) : '';

--- a/src/types.js
+++ b/src/types.js
@@ -73,6 +73,7 @@ import {Scope} from 'eslint-scope';
  * @property {ASTNode} [test]
  * @property {ASTNode} [tokens]
  * @property {Object[]} [trailingComments]
+ * @property {Object} [typeMap]
  * @property {ASTNode} [update]
  * @property {ASTNode|string|number|boolean} [value]
  */

--- a/tests/parsing.test.js
+++ b/tests/parsing.test.js
@@ -55,4 +55,22 @@ describe('Parsing tests', () => {
 		const result = generateCode(ast[0]);
 		assert.strictEqual(result, expected);
 	});
+	it(`Verify the type map is generated accurately`, () => {
+		const code = `class a {
+  static b = 1;
+  #c = 2;
+}`;
+		const expected = {
+			Program: [0],
+			ClassDeclaration: [1],
+			Identifier: [2, 5],
+			ClassBody: [3],
+			PropertyDefinition: [4, 7],
+			Literal: [6, 9],
+			PrivateIdentifier: [8],
+		};
+		const ast = generateFlatAST(code);
+		const result = ast[0].typeMap;
+		assert.deepEqual(result, expected);
+	});
 });

--- a/tests/parsing.test.js
+++ b/tests/parsing.test.js
@@ -60,16 +60,16 @@ describe('Parsing tests', () => {
   static b = 1;
   #c = 2;
 }`;
-		const expected = {
-			Program: [0],
-			ClassDeclaration: [1],
-			Identifier: [2, 5],
-			ClassBody: [3],
-			PropertyDefinition: [4, 7],
-			Literal: [6, 9],
-			PrivateIdentifier: [8],
-		};
 		const ast = generateFlatAST(code);
+		const expected = {
+			Program: [ast[0]],
+			ClassDeclaration: [ast[1]],
+			Identifier: [ast[2], ast[5]],
+			ClassBody: [ast[3]],
+			PropertyDefinition: [ast[4], ast[7]],
+			Literal: [ast[6], ast[9]],
+			PrivateIdentifier: [ast[8]],
+		};
 		const result = ast[0].typeMap;
 		assert.deepEqual(result, expected);
 	});


### PR DESCRIPTION
Add a typeMap object to the root node which maps node types to the actual nodes, so instead of iterating over the array to search for nodes, one can iterate over `rootNode.typeMap[<nodeType>]` for the relevant nodes