### PR TITLE
Fix Identifier Missing References

### DIFF
--- a/src/flast.js
+++ b/src/flast.js
@@ -233,10 +233,11 @@ function mapIdentifierRelations(node, scopeVarMaps) {
 			let decls = [];
 			if (variable) {
 				decls = variable.identifiers || [];
-			} else if (scope && scope.references) {
-				for (let i = 0; i < scope.references.length; i++) {
-					if (scope.references[i].identifier.name === node.name) {
-						decls = scope.references[i].resolved?.identifiers || [];
+			} else if (scope && (scope.references.length || scope.variableScope?.references.length)) {
+				const references = scope.references?.length ? scope.references : scope.variableScope.references;
+				for (let i = 0; i < references.length; i++) {
+					if (references[i].identifier.name === node.name) {
+						decls = references[i].resolved?.identifiers || [];
 						break;
 					}
 				}

--- a/tests/parsing.test.js
+++ b/tests/parsing.test.js
@@ -109,4 +109,11 @@ describe('Parsing tests', () => {
 		const ast = generateFlatAST(code);
 		assert.notEqual(ast, [1]);
 	});
+	it(`Verify all identifiers are referenced correctly`, () => {
+		const code = `let a = 1; switch(a) {}`;
+		const ast = generateFlatAST(code);
+		ast.filter(n => n.type === 'Identifier').forEach(n => {
+			assert.ok(n.references?.length || n.declNode, `Identifier '${n.name}' (#${n.nodeId}) is not referenced`);
+		});
+	});
 });


### PR DESCRIPTION
This pull request improves the handling of identifier references in the `mapIdentifierRelations` function and adds a new test case to ensure correct referencing of identifiers in the generated AST. These changes enhance both functionality and test coverage.

### Improvements to identifier reference handling:

* [`src/flast.js`](diffhunk://#diff-a0e2bce6bd503c58cb6f43d1e995139b536cb93f340fd47304f575fc4e1de201L236-R240): Updated the `mapIdentifierRelations` function to handle cases where `scope.references` might be empty by falling back to `scope.variableScope.references`. This ensures more robust resolution of identifier references.

### Enhancements to test coverage:

* [`tests/parsing.test.js`](diffhunk://#diff-2d458ad724fc7462898b577e7aea683ded9b45a0cbce1b2619e87096d4691be4R112-R118): Added a new test case to verify that all `Identifier` nodes in the AST are either referenced or have a declaration node. This ensures the correctness of identifier referencing in the AST.