### PR TITLE
Replace node src getter with substring.

### DIFF
--- a/src/flast.js
+++ b/src/flast.js
@@ -162,8 +162,12 @@ function extractNodesFromRoot(rootNode, opts) {
 				node.lineage.push(node.scope.scopeId);
 			}
 		}
-		// Add a getter for the node's source code
-		if (opts.includeSrc && !node.src) node.src = rootNode.src.substring(node.start,node.end);
+		// Avoid using a getter with a closure around source here, as the 
+		// memory requirement for a function per node is far greater than using 
+		// a string reference for sufficiently large AST Trees 
+		// (~2.4 nodes for 3 Gib).
+		if (opts.includeSrc && !node.src) 
+			node.src = rootNode.src.substring(node.start,node.end);
 	}
 	if (opts.detailed) {
 		const identifiers = typeMap.Identifier || [];

--- a/src/flast.js
+++ b/src/flast.js
@@ -39,15 +39,6 @@ const generateFlatASTDefaultOptions = {
 };
 
 /**
- * Return a function which retrieves a node's source on demand
- * @param {string} src
- * @returns {function(number, number): string}
- */
-function createSrcClosure(src) {
-	return function(start, end) {return src.slice(start, end);};
-}
-
-/**
  * @param {string} inputCode
  * @param {object} opts Optional changes to behavior. See generateFlatASTDefaultOptions for available options.
  * @return {ASTNode[]} An array of flattened AST
@@ -96,13 +87,13 @@ function generateRootNode(inputCode, opts = {}) {
 	let rootNode;
 	try {
 		rootNode = parseCode(inputCode, parseOpts);
-		if (opts.includeSrc) rootNode.srcClosure = createSrcClosure(inputCode);
+		if (opts.includeSrc) rootNode.src = inputCode;
 	} catch (e) {
 		// If any parse error occurs and alternateSourceTypeOnFailure is set, try 'script' mode
 		if (opts.alternateSourceTypeOnFailure) {
 			try {
 				rootNode = parseCode(inputCode, {...parseOpts, sourceType: 'script'});
-				if (opts.includeSrc) rootNode.srcClosure = createSrcClosure(inputCode);
+				if (opts.includeSrc) rootNode.src = inputCode;
 			} catch (e2) {
 				logger.debug('Failed to parse as module and script:', e, e2);
 			}
@@ -172,9 +163,7 @@ function extractNodesFromRoot(rootNode, opts) {
 			}
 		}
 		// Add a getter for the node's source code
-		if (opts.includeSrc && !node.src) Object.defineProperty(node, 'src', {
-			get() {return rootNode.srcClosure(node.start, node.end);},
-		});
+		if (opts.includeSrc && !node.src) node.src = rootNode.src.substring(node.start,node.end);
 	}
 	if (opts.detailed) {
 		const identifiers = typeMap.Identifier || [];


### PR DESCRIPTION
While the srcClosure for the node.src property seems like a good idea for dynamically getting the src. The cost of the getter function is not free, and for high AST Node count trees this can be quite high.

I'm seeing ~2.9 Gib for ~2.3Mil Nodes, which when combined with the tree returned from espress (~1.3gib) causes an OOM in the default 4 Gib memory space.

Replacing the getter with a substring of the source gets 2.7 Gib for 3.1Mil nodes.

1358 bytes ->  931 bytes per node for my test file. ~30% reduction.

<details>
<summary> Restringer test suite </summary>

❯ npm run test

> restringer@2.1.0 test
> node --test --trace-warnings --no-node-snapshot

▶ Deobfuscation tests
  ✔ Augmented Array Replacements (32.601772ms)
  ✔ Compute definite binary expressions (3.535006ms)
  ✔ Don't replace modified member expressions (3.013914ms)
  ✔ Don't replace member expressions on empty arrays (1.339312ms)
  ﹣ TODO: Fix. Normalize Script Correctly (0.103303ms) # SKIP
  ✔ Parse template literals into string literals (4.160426ms)
  ✔ Remove nested block statements (5.686532ms)
  ✔ Remove redundant logical expressions (13.55608ms)
  ✔ Remove redundant not operators (9.033679ms)
  ✔ Replace augmented function with corrected array (16.678157ms)
  ✔ Replace deterministic if statement (2.467701ms)
  ✔ Replace function calls with unwrapped identifier - arrow functions (5.848909ms)
  ✔ Replace function calls with unwrapped identifier - function declarations (6.281961ms)
  ✔ Replace function evals - eval(string) (1.894889ms)
  ✔ Replace function evals in call expressions - eval(string)(args) (3.010999ms)
  ✔ Replace identifier with fixed assigned value (7.083277ms)
  ✔ Replace literal proxies (4.138803ms)
  ✔ Replace local calls proxy - arrow functions (13.567394ms)
  ﹣ TODO: FIX Replace local calls proxy - function declarations (0.06021ms) # SKIP
  ✔ Replace local calls with values - immediate (1.061089ms)
  ✔ Replace local calls with values - nested (10.796405ms)
  ✔ Replace local member expressions property reference with value (9.623682ms)
  ✔ Replace local member expressions proxy - chained proxies (7.553001ms)
  ✔ Replace local member expressions proxy - member assignment (2.416962ms)
  ✔ Replace member expression references with values (13.210975ms)
  ✔ Replace reference proxy (12.897601ms)
  ✔ Replace wrapped functions with return statement (5.204005ms)
  ✔ Resolve builtin call expressions: btoa & atob (4.243346ms)
  ✔ Resolve definite member expressions (3.644727ms)
  ✔ Resolve deterministic conditional expressions (3.983627ms)
  ✔ Resolve directly assigned member expressions (5.544015ms)
  ✔ Resolve external references with context (13.500312ms)
  ✔ Resolve function constructor calls (8.726752ms)
  ✔ Resolve injected prototype method calls (9.484584ms)
  ✔ Resolve member expression local references with unary expressions correctly (10.780293ms)
  ✔ Resolve member expression references with context (4.733457ms)
  ✔ Unwrap function shells (0.94462ms)
  ✔ Verify correct context for function declaration (7.668021ms)
  ✔ Verify correct context for function variable (3.983416ms)
  ✔ Verify correct replacement of member expressions with literals (4.165173ms)
  ✔ Verify random values remain untouched (5.510278ms)
✔ Deobfuscation tests (287.067532ms)
▶ Functionality tests
  ✔ Set max iterations (14.883418ms)
  ✔ REstringer.__version__ is populated (0.187887ms)
✔ Functionality tests (16.184853ms)
▶ SAFE: removeRedundantBlockStatements
  ✔ TP-1 (12.756444ms)
  ✔ TP-2 (2.383905ms)
  ✔ TP-3 (3.418152ms)
  ✔ TP-4 (2.662003ms)
✔ SAFE: removeRedundantBlockStatements (23.187071ms)
▶ SAFE: normalizeComputed
  ✔ TP-1: Convert valid string identifiers to dot notation (2.543375ms)
  ✔ TP-2: Convert object properties with valid identifiers (3.702239ms)
  ✔ TP-3: Convert class method definitions with valid identifiers (3.697643ms)
  ✔ TN-1: Do not convert invalid identifiers (0.760553ms)
  ✔ TN-2: Do not convert numeric indices but convert valid string (1.234213ms)
✔ SAFE: normalizeComputed (12.613463ms)
▶ SAFE: normalizeEmptyStatements
  ✔ TP-1: Remove standalone empty statements (1.368449ms)
  ✔ TP-2: Remove empty statements in blocks (2.492208ms)
  ✔ TN-1: Preserve empty statements in for-loops (0.999977ms)
  ✔ TN-2: Preserve empty statements in while-loops (0.630348ms)
  ✔ TN-3: Preserve empty statements in if-statements (0.720048ms)
  ✔ TN-4: Preserve empty statements in do-while loops (0.69961ms)
  ✔ TN-5: Preserve empty statements in for-in loops (0.404188ms)
✔ SAFE: normalizeEmptyStatements (7.720385ms)
▶ SAFE: parseTemplateLiteralsIntoStringLiterals
  ✔ TP-1: Convert template literal with string expression (2.064862ms)
  ✔ TP-2: Convert template literal with multiple expressions (0.894226ms)
  ✔ TP-3: Convert template literal with no expressions (0.629304ms)
  ✔ TP-4: Convert template literal with boolean and number expressions (0.993396ms)
  ✔ TP-5: Convert empty template literal (0.608878ms)
  ✔ TN-1: Do not convert template literal with variable expression (0.433011ms)
  ✔ TN-2: Do not convert template literal with function call expression (0.493362ms)
  ✔ TN-3: Do not convert template literal with mixed literal and non-literal expressions (0.351628ms)
✔ SAFE: parseTemplateLiteralsIntoStringLiterals (6.86647ms)
▶ SAFE: rearrangeSequences
  ✔ TP-1: Split sequenced calls to standalone expressions (1.81515ms)
  ✔ TP-2: Split sequenced calls to standalone expressions in if-statements (1.399696ms)
  ✔ TP-3: Split sequenced calls in if-statements to cascading if-statements (0.756209ms)
  ✔ TP-4: Split sequenced calls in nested if-statements to cascading if-statements (0.836147ms)
  ✔ TP-5: Split sequences with more than three expressions (1.086808ms)
  ✔ TP-6: Split sequences in if condition with else clause (0.984422ms)
  ✔ TN-1: Do not transform single expression returns (0.47823ms)
  ✔ TN-2: Do not transform single expression if conditions (0.375178ms)
  ✔ TN-3: Do not transform non-sequence expressions (0.564617ms)
✔ SAFE: rearrangeSequences (8.840449ms)
▶ SAFE: rearrangeSwitches
  ✔ TP-1: Complex switch with multiple cases and return statement (4.475516ms)
  ✔ TP-2: Simple switch with sequential cases (1.45513ms)
  ✔ TP-3: Switch with default case (1.043208ms)
  ✔ TP-4: Switch starting with non-initial case via default (1.199605ms)
  ✔ TN-1: Do not transform switch without literal discriminant initialization (0.433052ms)
  ✔ TP-5: Transform switch but stop at multiple assignments to discriminant (1.040384ms)
  ✔ TN-2: Do not transform switch with non-literal case value (0.431032ms)
✔ SAFE: rearrangeSwitches (10.438024ms)
▶ SAFE: removeDeadNodes
  ✔ TP-1 (0.980128ms)
✔ SAFE: removeDeadNodes (1.080554ms)
▶ SAFE: replaceCallExpressionsWithUnwrappedIdentifier
  ✔ TP-1: Replace call expression with identifier behind an arrow function (2.319665ms)
  ✔ TP-2: Replace call expression with identifier behind a function declaration (0.958206ms)
  ✔ TP-3: Replace call expression with function expression assigned to variable (0.880757ms)
  ✔ TP-4: Replace call expression with arrow function using block statement (0.90012ms)
  ✔ TP-5: Replace call expression returning parameterless call (0.689531ms)
  ✔ TN-1: Do not replace function returning call expression with arguments (0.405097ms)
  ✔ TN-2: Do not replace function with multiple statements (0.48837ms)
  ✔ TN-3: Do not replace function with no return statement (0.379097ms)
  ✔ TN-4: Do not replace non-function callee (0.32877ms)
✔ SAFE: replaceCallExpressionsWithUnwrappedIdentifier (7.722225ms)
▶ SAFE: replaceEvalCallsWithLiteralContent
  ✔ TP-1: Replace eval call with the code parsed from the argument string (1.320592ms)
  ✔ TP-2: Replace eval call with a block statement with multiple expression statements (0.753058ms)
  ✔ TP-3: Replace eval call with the code in a return statement (0.95709ms)
  ✔ TP-4: Replace eval call wrapped in a call expression (1.073517ms)
  ✔ TP-5: Replace eval call wrapped in a binary expression (1.201571ms)
  ✔ TP-6: Unwrap expression statement from replacement where needed (0.643206ms)
  ✔ TP-7: Replace eval with single expression in conditional (0.622261ms)
  ✔ TP-8: Replace eval with function declaration (0.873805ms)
  ✔ TN-1: Do not replace eval with non-literal argument (0.344285ms)
  ✔ TN-2: Do not replace non-eval function calls (0.254013ms)
  ✔ TN-3: Do not replace eval with invalid syntax (1.013114ms)
  ✔ TN-4: Do not replace eval with no arguments (0.269807ms)
✔ SAFE: replaceEvalCallsWithLiteralContent (9.853124ms)
▶ SAFE: replaceFunctionShellsWithWrappedValue
  ✔ TP-1: Replace references with identifier (0.982194ms)
  ✔ TP-2: Replace function returning literal number (0.731607ms)
  ✔ TP-3: Replace function returning literal string (0.653579ms)
  ✔ TP-4: Replace function returning boolean literal (0.733463ms)
  ✔ TP-5: Replace multiple calls to same function (0.802799ms)
  ✔ TN-1: Should not replace literals 1 (0.468012ms)
  ✔ TN-2: Should not replace literals 2 (0.395214ms)
  ✔ TN-3: Do not replace function with multiple statements (0.487677ms)
  ✔ TN-4: Do not replace function with no return statement (0.433497ms)
  ✔ TN-5: Do not replace function returning complex expression (0.38493ms)
  ✔ TN-6: Do not replace function used as callback (0.452361ms)
✔ SAFE: replaceFunctionShellsWithWrappedValue (7.032269ms)
▶ SAFE: replaceFunctionShellsWithWrappedValueIIFE
  ✔ TP-1: Replace with wrapped value in-place (0.815842ms)
  ✔ TP-2: Replace IIFE returning literal number (0.589482ms)
  ✔ TP-3: Replace IIFE returning literal string (0.57426ms)
  ✔ TP-4: Replace IIFE returning boolean literal (0.61915ms)
  ✔ TP-5: Replace IIFE returning identifier (0.696197ms)
  ✔ TP-6: Replace multiple IIFEs in expression (0.782311ms)
  ✔ TN-1: Do not replace IIFE with arguments (0.877801ms)
  ✔ TN-2: Do not replace IIFE with multiple statements (0.435199ms)
  ✔ TN-3: Do not replace IIFE with no return statement (0.360065ms)
  ✔ TN-4: Do not replace IIFE returning complex expression (0.352142ms)
  ✔ TN-5: Do not replace function expression not used as IIFE (0.345107ms)
  ✔ TN-6: Do not replace function expression without a return value (0.290825ms)
✔ SAFE: replaceFunctionShellsWithWrappedValueIIFE (7.235046ms)
▶ SAFE: replaceIdentifierWithFixedAssignedValue
  ✔ TP-1: Replace references with number literal (1.397826ms)
  ✔ TP-2: Replace references with string literal (0.822279ms)
  ✔ TP-3: Replace references with boolean literal (0.863899ms)
  ✔ TP-4: Replace multiple different variables (0.830174ms)
  ✔ TP-5: Replace with null literal (0.96929ms)
  ✔ TP-6: Replace with let declaration (0.904774ms)
  ✔ TP-7: Replace with var declaration (0.892124ms)
  ✔ TN-1: Do no replace a value used in a for-in-loop (0.863502ms)
  ✔ TN-2: Do no replace a value used in a for-of-loop (0.59272ms)
  ✔ TN-3: Do not replace variable with non-literal initializer (0.416635ms)
  ✔ TN-4: Do not replace object property names (0.43479ms)
  ✔ TN-5: Do not replace modified variables (0.582058ms)
  ✔ TN-6: Do not replace reassigned variables (0.46119ms)
  ✔ TN-7: Do not replace variable without declaration (0.305783ms)
✔ SAFE: replaceIdentifierWithFixedAssignedValue (10.972868ms)
▶ SAFE: replaceIdentifierWithFixedValueNotAssignedAtDeclaration
  ✔ TP-1: Replace identifier with number literal (1.828191ms)
  ✔ TP-2: Replace identifier with string literal (0.846219ms)
  ✔ TP-3: Replace identifier with boolean literal (0.949567ms)
  ✔ TP-4: Replace identifier with null literal (0.772422ms)
  ✔ TP-5: Replace var declaration (0.775625ms)
  ✔ TP-6: Replace with multiple references (0.870629ms)
  ✔ TN-1: Do not replace variable used in for-in loop (0.558658ms)
  ✔ TN-2: Do not replace variable used in for-of loop (0.475561ms)
  ✔ TN-3: Do not replace variable in conditional expression context (0.646544ms)
  ✔ TN-4: Do not replace variable with multiple assignments (0.432407ms)
  ✔ TN-5: Do not replace variable assigned non-literal value (0.448097ms)
  ✔ TN-6: Do not replace function callee (0.402005ms)
  ✔ TN-7: Do not replace variable with initial value (0.431934ms)
  ✔ TN-8: Do not replace when references are modified (0.478676ms)
✔ SAFE: replaceIdentifierWithFixedValueNotAssignedAtDeclaration (10.537018ms)
▶ SAFE: replaceNewFuncCallsWithLiteralContent
  ✔ TP-1: Replace Function constructor with IIFE (1.829989ms)
  ✔ TP-2: Replace Function constructor with single expression (0.847903ms)
  ✔ TP-3: Replace Function constructor with multiple statements (1.257694ms)
  ✔ TP-4: Replace Function constructor with empty string (0.583356ms)
  ✔ TP-5: Replace Function constructor with variable declaration (1.068545ms)
  ✔ TN-1: Do not replace Function constructor with arguments (0.50168ms)
  ✔ TN-2: Do not replace Function constructor with multiple parameters (0.344327ms)
  ✔ TN-3: Do not replace Function constructor with non-literal argument (0.342909ms)
  ✔ TN-4: Do not replace non-Function constructor (0.417789ms)
  ✔ TN-5: Do not replace Function constructor not used as callee (0.556316ms)
  ✔ TN-6: Do not replace Function constructor with invalid syntax (0.728508ms)
✔ SAFE: replaceNewFuncCallsWithLiteralContent (9.05446ms)
▶ SAFE: replaceBooleanExpressionsWithIf
  ✔ TP-1: Simple logical AND (0.980257ms)
  ✔ TP-2: Simple logical OR (0.578992ms)
  ✔ TP-3: Chained logical AND (0.768837ms)
  ✔ TP-4: Chained logical OR (0.715009ms)
  ✔ TP-5: Function call in condition (0.599853ms)
  ✔ TP-6: Member expression in condition (0.598788ms)
  ✔ TN-1: Do not transform non-logical expressions (0.272305ms)
  ✔ TN-2: Do not transform logical expressions not in expression statements (0.3255ms)
  ✔ TN-3: Do not transform bitwise operators (0.304524ms)
✔ SAFE: replaceBooleanExpressionsWithIf (5.585989ms)
▶ SAFE: replaceSequencesWithExpressions
  ✔ TP-1: Replace sequence with 2 expressions in if statement (1.016253ms)
  ✔ TP-2: Replace sequence with 3 expressions within existing block (1.032217ms)
  ✔ TP-3: Replace sequence in while loop (0.879011ms)
  ✔ TP-4: Replace sequence with 4 expressions (0.787711ms)
  ✔ TP-5: Replace sequence in for loop body (1.604538ms)
  ✔ TP-6: Replace sequence with mixed expression types (0.892758ms)
  ✔ TP-7: Replace sequence in else clause (0.706876ms)
  ✔ TN-1: Do not replace single expression (not a sequence) (0.260656ms)
  ✔ TN-2: Do not replace sequence with only one expression (0.308695ms)
  ✔ TN-3: Do not replace sequence in non-ExpressionStatement context (0.347869ms)
  ✔ TN-4: Do not replace sequence in return statement (0.329433ms)
  ✔ TN-5: Do not replace sequence in assignment (0.351839ms)
✔ SAFE: replaceSequencesWithExpressions (10.359069ms)
▶ SAFE: resolveDeterministicIfStatements
  ✔ TP-1: Resolve true and false literals (0.966076ms)
  ✔ TP-2: Resolve truthy number literal (0.596433ms)
  ✔ TP-3: Resolve falsy number literal (0) (0.572073ms)
  ✔ TP-4: Resolve truthy string literal (0.619321ms)
  ✔ TP-5: Resolve falsy string literal (empty) (0.55377ms)
  ✔ TP-6: Resolve null literal (0.477915ms)
  ✔ TP-7: Resolve if statement with no else clause (truthy) (0.386791ms)
  ✔ TP-8: Remove if statement with no else clause (falsy) (0.583427ms)
  ✔ TP-9: Resolve negative number literal (0.590991ms)
  ✔ TP-10: Resolve nested if statements (0.54527ms)
  ✔ TN-1: Do not resolve if with variable condition (0.31113ms)
  ✔ TN-2: Do not resolve if with function call condition (0.345506ms)
  ✔ TN-3: Do not resolve if with expression condition (0.355367ms)
  ✔ TN-4: Do not resolve if with member expression condition (0.373184ms)
✔ SAFE: resolveDeterministicIfStatements (7.843068ms)
▶ SAFE: resolveFunctionConstructorCalls
  ✔ TP-1: Replace Function.constructor with no parameters (1.650172ms)
  ✔ TP-2: Part of a member expression (3.463435ms)
  ✔ TP-3: Replace Function.constructor with single parameter (1.514276ms)
  ✔ TP-4: Replace Function.constructor with multiple parameters (1.014934ms)
  ✔ TP-5: Replace Function.constructor with complex body (0.889353ms)
  ✔ TP-6: Replace Function.constructor with empty body (0.595534ms)
  ✔ TP-7: Replace Function.constructor in variable assignment (0.785599ms)
  ✔ TP-8: Replace Function.constructor in call expression (0.636108ms)
  ✔ TN-1: Do not replace Function.constructor with non-literal arguments (0.316026ms)
  ✔ TN-2: Do not replace Function.constructor with no arguments (0.290671ms)
  ✔ TN-3: Do not replace non-constructor calls (0.271684ms)
  ✔ TN-4: Do not replace Function.constructor with invalid syntax body (0.508296ms)
  ✔ TP-9: Replace any constructor call with literal arguments (0.628048ms)
✔ SAFE: resolveFunctionConstructorCalls (13.102753ms)
▶ SAFE: resolveMemberExpressionReferencesToArrayIndex
  ✔ TP-1 (1.713322ms)
  ✔ TP-2: Replace multiple array accesses on same array (1.604034ms)
  ✔ TP-3: Replace array access with string literal elements (1.227185ms)
  ✔ TP-4: Replace array access in function call arguments (1.398745ms)
  ✔ TN-1: Don't resolve references to array methods (0.668036ms)
  ✔ TN-2: Do not resolve arrays smaller than minimum length (0.565479ms)
  ✔ TN-3: Do not resolve assignment to array elements (0.744177ms)
  ✔ TN-4: Do not resolve computed property access with variables (0.736451ms)
  ✔ TN-5: Do not resolve out-of-bounds array access (0.585759ms)
  ✔ TN-6: Do not resolve negative array indices (0.621745ms)
  ✔ TN-7: Do not resolve floating point indices (0.577413ms)
✔ SAFE: resolveMemberExpressionReferencesToArrayIndex (10.98964ms)
▶ SAFE: resolveMemberExpressionsWithDirectAssignment
  ✔ TP-1: Replace direct property assignments with literal values (1.482199ms)
  ✔ TP-2: Replace object property assignments (1.151591ms)
  ✔ TP-3: Replace computed property assignments (0.901312ms)
  ✔ TP-4: Replace boolean and null assignments (1.07697ms)
  ✔ TP-5: Replace multiple references to same property (1.132038ms)
  ✔ TN-1: Don't resolve with multiple assignments (0.426328ms)
  ✔ TN-2: Don't resolve with update expressions (0.441438ms)
  ✔ TN-3: Do not resolve when assigned non-literal value (0.435297ms)
  ✔ TN-4: Do not resolve when object has no declaration (0.372519ms)
  ✔ TN-5: Do not resolve when property is reassigned (0.450936ms)
  ✔ TN-6: Do not resolve when used in assignment expression (0.449848ms)
  ✔ TN-7: Do not resolve when property is computed with variable (0.461496ms)
  ✔ TN-8: Do not resolve when no references exist (0.302229ms)
✔ SAFE: resolveMemberExpressionsWithDirectAssignment (9.74582ms)
▶ SAFE: resolveProxyCalls
  ✔ TP-1: Replace chained proxy calls with direct function calls (2.061224ms)
  ✔ TP-2: Replace proxy with no parameters (1.002534ms)
  ✔ TP-3: Replace proxy with multiple parameters (1.300683ms)
  ✔ TP-4: Replace proxy that calls another proxy (single-step resolution) (1.721122ms)
  ✔ TN-1: Do not replace function with multiple statements (0.416815ms)
  ✔ TN-2: Do not replace function with no return statement (0.389941ms)
  ✔ TN-3: Do not replace function that returns non-call expression (0.327621ms)
  ✔ TN-4: Do not replace function that calls member expression (0.647235ms)
  ✔ TN-5: Do not replace function with parameter count mismatch (1.873726ms)
  ✔ TN-6: Do not replace function with reordered parameters (0.402509ms)
  ✔ TN-7: Do not replace function with modified parameters (0.48628ms)
  ✔ TN-8: Do not replace function with no references (0.304948ms)
✔ SAFE: resolveProxyCalls (11.465499ms)
▶ SAFE: resolveProxyReferences
  ✔ TP-1: Replace proxy reference with direct reference (1.198394ms)
  ✔ TP-2: Replace multiple proxy references to same target (0.762566ms)
  ✔ TP-3: Replace member expression proxy references (0.880492ms)
  ✔ TP-4: Replace chained proxy references (0.675941ms)
  ✔ TP-5: Replace variable with let declaration (0.653619ms)
  ✔ TP-6: Replace variable with var declaration (0.600819ms)
  ✔ TN-1: Do not replace proxy in for-in statement (0.496319ms)
  ✔ TN-2: Do not replace proxy in for-of statement (0.366569ms)
  ✔ TN-3: Do not replace proxy in for statement (0.404734ms)
  ✔ TN-4: Do not replace circular references (0.267918ms)
  ✔ TN-5: Do not replace self-referencing variables (0.208318ms)
  ✔ TN-6: Do not replace when proxy is modified (0.288887ms)
  ✔ TN-7: Do not replace when target is modified (0.305065ms)
  ✔ TN-8: Do not replace when proxy has no references (0.250253ms)
  ✔ TN-9: Do not replace non-identifier/non-member expression variables (0.250331ms)
  ✔ TP-7: Replace when target comes from function call (still safe) (0.547036ms)
✔ SAFE: resolveProxyReferences (8.671105ms)
▶ SAFE: resolveProxyVariables
  ✔ TP-1: Replace proxy variable references with target identifier (1.170878ms)
  ✔ TP-2: Remove unused proxy variable declaration (0.943139ms)
  ✔ TP-3: Replace multiple references to same proxy (0.922082ms)
  ✔ TP-4: Remove proxy variable with no references (0.487329ms)
  ✔ TP-5: Replace with let declaration (0.749902ms)
  ✔ TP-6: Replace with var declaration (0.642725ms)
  ✔ TN-1: Do not replace when proxy is assigned non-identifier (0.256593ms)
  ✔ TN-2: Do not replace when proxy is modified (0.333541ms)
  ✔ TN-3: Do not replace when proxy is updated (0.330422ms)
  ✔ TN-4: Do not replace when reference is used in assignment (0.287942ms)
  ✔ TN-5: Do not replace non-identifier initialization (0.278263ms)
✔ SAFE: resolveProxyVariables (6.813284ms)
▶ SAFE: resolveRedundantLogicalExpressions
  ✔ TP-1: Simplify basic true and false literals with && and || (0.884791ms)
  ✔ TP-2: Simplify AND expressions with truthy left operand (0.734167ms)
  ✔ TP-3: Simplify AND expressions with falsy left operand (0.572212ms)
  ✔ TP-4: Simplify AND expressions with truthy right operand (0.623943ms)
  ✔ TP-5: Simplify AND expressions with falsy right operand (0.569798ms)
  ✔ TP-6: Simplify OR expressions with truthy left operand (0.486189ms)
  ✔ TP-7: Simplify OR expressions with falsy left operand (0.571523ms)
  ✔ TP-8: Simplify OR expressions with truthy right operand (0.594911ms)
  ✔ TP-9: Simplify OR expressions with falsy right operand (0.563505ms)
  ✔ TP-10: Handle complex expressions with nested logical operators (0.522332ms)
  ✔ TN-1: Do not simplify when both operands are non-literals (0.412998ms)
  ✔ TN-2: Do not simplify non-logical expressions (0.346031ms)
  ✔ TN-3: Do not simplify logical expressions outside if statements (0.355565ms)
  ✔ TN-4: Do not simplify unsupported logical operators (if any) (0.312171ms)
✔ SAFE: resolveRedundantLogicalExpressions (8.1252ms)
▶ SAFE: unwrapFunctionShells
  ✔ TP-1: Unwrap and rename (1.327649ms)
  ✔ TP-2: Unwrap anonymous without renaming (0.725185ms)
  ✔ TP-3: Unwrap function expression assigned to variable (0.707759ms)
  ✔ TP-4: Inner function already has parameters (0.674626ms)
  ✔ TP-5: Outer function has multiple parameters (0.71482ms)
  ✔ TP-6: Complex inner function body (0.78225ms)
  ✔ TN-1: Do not unwrap function with multiple statements (0.400361ms)
  ✔ TN-2: Do not unwrap function with no return statement (0.328456ms)
  ✔ TN-3: Do not unwrap function returning .call instead of .apply (0.376628ms)
  ✔ TN-4: Do not unwrap .apply with wrong argument count (0.366352ms)
  ✔ TN-5: Do not unwrap when callee object is not FunctionExpression (0.376625ms)
  ✔ TN-6: Do not unwrap function returning non-call expression (0.331558ms)
  ✔ TN-7: Do not unwrap function with empty body (0.247389ms)
  ✔ TN-8: Do not unwrap function with BlockStatement but no statements (0.220787ms)
  ✔ TN-9: Do not unwrap arrow function as outer function (0.512871ms)
✔ SAFE: unwrapFunctionShells (8.642164ms)
▶ SAFE: unwrapIIFEs
  ✔ TP-1: Arrow functions (1.252551ms)
  ✔ TP-2: Function expressions (0.850741ms)
  ✔ TP-3: In-place unwrapping (0.726377ms)
  ✔ TN-1: Unary declarator init (0.434992ms)
  ✔ TN-2: Unary assignment right (0.544053ms)
  ✔ TP-4: IIFE with multiple statements unwrapped (0.881128ms)
  ✔ TN-3: Do not unwrap IIFE with arguments (0.397494ms)
  ✔ TN-4: Do not unwrap named function IIFE (0.348379ms)
  ✔ TN-5: Do not unwrap IIFE in assignment context (0.351332ms)
  ✔ TP-5: Arrow function IIFE with expression body (0.418115ms)
✔ SAFE: unwrapIIFEs (6.587973ms)
▶ SAFE: unwrapSimpleOperations
  ✔ TP-1: Binary operations (10.025707ms)
  ✔ TP-2 Unary operations (2.991025ms)
  ✔ TP-3 Update operations (1.539143ms)
  ✔ TN-1: Do not unwrap function with multiple statements (0.528253ms)
  ✔ TN-2: Do not unwrap function with wrong parameter count (0.444033ms)
  ✔ TN-3: Do not unwrap operation not using parameters (0.414405ms)
  ✔ TN-4: Do not unwrap function with no return statement (0.378236ms)
  ✔ TN-5: Do not unwrap unsupported operator (0.360175ms)
✔ SAFE: unwrapSimpleOperations (17.054982ms)
▶ SAFE: separateChainedDeclarators
  ✔ TP-1: A single const (0.852105ms)
  ✔ TP-2: A single let (0.544082ms)
  ✔ TP-3: A var and a let (1.283146ms)
  ✔ TP-3: Wrap in a block statement for a one-liner (0.852958ms)
  ✔ TP-5: Mixed initialization patterns (0.449226ms)
  ✔ TP-6: Mixed declaration types with complex expressions (0.776719ms)
  ✔ TP-7: Three or more declarations (0.572018ms)
  ✔ TP-8: Declarations in function scope (0.671387ms)
  ✔ TN-1: Variable declarators are not chained in for statement (0.355313ms)
  ✔ TN-2: Variable declarators are not chained in for-in statement (0.276895ms)
  ✔ TN-3: Variable declarators are not chained in for-of statement (0.238312ms)
  ✔ TN-4: Single declarator should not be transformed (0.285869ms)
  ✔ TN-5: ForAwaitStatement declarations should be preserved (0.330226ms)
  ✔ TN-6: Destructuring patterns should not be separated (1.257959ms)
✔ SAFE: separateChainedDeclarators (9.818416ms)
▶ SAFE: simplifyCalls
  ✔ TP-1: With args (0.999875ms)
  ✔ TP-2: Without args (0.438718ms)
  ✔ TP-3: Mixed calls with complex arguments (0.647464ms)
  ✔ TP-4: Calls on member expressions (0.550886ms)
  ✔ TP-5: Apply with empty array (0.34187ms)
  ✔ TP-6: Call and apply in same expression (0.628181ms)
  ✔ TP-7: Call and apply with null for context (0.467316ms)
  ✔ TN-1: Ignore calls without ThisExpression (0.415851ms)
  ✔ TN-2: Do not transform Function constructor calls (0.330387ms)
  ✔ TN-3: Do not transform calls on function expressions (0.436075ms)
  ✔ TN-4: Do not transform other method names (0.391194ms)
  ✔ TN-5: Do not transform calls with this in wrong position (0.33444ms)
✔ SAFE: simplifyCalls (6.430088ms)
▶ SAFE: simplifyIfStatements
  ✔ TP-1: Empty blocks (0.726483ms)
  ✔ TP-2: Empty blocks with an empty alternate statement (0.36029ms)
  ✔ TP-3: Empty blocks with a populated alternate statement (0.491793ms)
  ✔ TP-4: Empty blocks with a populated alternate block (0.433924ms)
  ✔ TP-5: Empty statements (0.312009ms)
  ✔ TP-6: Empty statements with no alternate (0.286413ms)
  ✔ TP-7: Empty statements with an empty alternate (0.291956ms)
  ✔ TP-8: Populated consequent with empty alternate block (0.406828ms)
  ✔ TP-9: Populated consequent with empty alternate statement (0.34304ms)
  ✔ TP-10: Complex expression in test with empty branches (0.409311ms)
  ✔ TP-11: Nested empty if statements (0.440016ms)
  ✔ TN-1: Do not transform if with populated consequent and alternate (0.245983ms)
  ✔ TN-2: Do not transform if with populated block statements (0.305091ms)
  ✔ TN-3: Do not transform if with only populated consequent block (0.205932ms)
  ✔ TN-4: Do not transform complex if-else chains (0.27018ms)
✔ SAFE: simplifyIfStatements (6.009373ms)
▶ UNSAFE: normalizeRedundantNotOperator
  ✔ TP-1: Mixed literals and expressions (22.015936ms)
  ✔ TP-2: String literals (4.095302ms)
  ✔ TP-3: Number literals (4.180927ms)
  ✔ TP-4: Null literal (4.88498ms)
  ✔ TP-5: Empty array and object literals (3.1101ms)
  ✔ TP-6: Simple nested NOT operations (2.926122ms)
  ✔ TP-7: Normalize complex literals that can be safely evaluated (4.853661ms)
  ✔ TN-1: Do not normalize NOT on variables (1.121373ms)
  ✔ TN-2: Do not normalize NOT on complex expressions (1.523779ms)
  ✔ TN-3: Do not normalize NOT on function calls (1.021345ms)
  ✔ TN-4: Do not normalize NOT on computed properties (0.573625ms)
  ✔ TN-5: Do not normalize literals with unpredictable values (0.390399ms)
✔ UNSAFE: normalizeRedundantNotOperator (53.243424ms)
▶ UNSAFE: resolveAugmentedFunctionWrappedArrayReplacements
  ✔ Add Missing True Positive Test Cases (1.865339ms) # TODO
  ✔ TN-1: Do not transform functions without augmentation (2.486722ms)
  ✔ TN-2: Do not transform functions without array operations (1.43ms)
  ✔ TN-3: Do not transform when no matching expression statements (1.552367ms)
  ✔ TN-4: Do not transform anonymous functions (0.65724ms)
  ✔ TN-5: Do not transform when array candidate has no declNode (0.61355ms)
  ✔ TN-6: Do not transform when expression statement pattern is wrong (1.69329ms)
  ✔ TN-7: Do not transform when no replacement candidates found (1.288944ms)
✔ UNSAFE: resolveAugmentedFunctionWrappedArrayReplacements (12.11289ms)
▶ UNSAFE: resolveBuiltinCalls
  ✔ TP-1: atob (3.894202ms)
  ✔ TP-2: btoa (3.451134ms)
  ✔ TP-3: split (3.597144ms)
  ✔ TP-4: Member expression with literal arguments (3.514328ms)
  ✔ TP-5: Multiple builtin calls (3.138883ms)
  ✔ TP-6: String method with multiple arguments (3.227359ms)
  ✔ TN-1: querySelector (0.402285ms)
  ✔ TN-2: Unknown variable (3.660578ms)
  ✔ TN-3: Overwritten builtin (0.686564ms)
  ✔ TN-4: Skip builtin function call (0.345039ms)
  ✔ TN-5: Skip member expression with restricted property (0.277063ms)
  ✔ TN-6: Function call with this expression (0.380075ms)
  ✔ TN-7: Constructor property access (0.331954ms)
  ✔ TN-8: Member expression with computed property using variable (3.724659ms)
✔ UNSAFE: resolveBuiltinCalls (31.312703ms)
▶ UNSAFE: resolveDefiniteBinaryExpressions
  ✔ TP-1: Mixed arithmetic and string operations (5.145724ms)
  ✔ TP-2: Division and modulo operations (3.77457ms)
  ✔ TP-3: Bitwise operations (3.656939ms)
  ✔ TP-4: Comparison operations (3.723603ms)
  ✔ TP-5: Negative number edge case handling (3.592481ms)
  ✔ TP-6: Null operations and string concatenation (3.466835ms)
  ✔ TN-1: Do not resolve expressions with variables (0.41422ms)
  ✔ TN-2: Do not resolve expressions with function calls (0.440103ms)
  ✔ TN-3: Do not resolve member expressions (0.4883ms)
  ✔ TN-4: Do not resolve complex nested expressions (0.50736ms)
  ✔ TN-5: Do not resolve logical expressions (not BinaryExpressions) (0.384035ms)
  ✔ TN-6: Do not resolve expressions with undefined identifier (0.330066ms)
  ✔ Helper TP-1: Literal node (0.396525ms)
  ✔ Helper TP-2: Binary expression with literals (0.33411ms)
  ✔ Helper TP-3: Unary expression with literal (0.279723ms)
  ✔ Helper TP-4: Complex nested binary expressions (0.336929ms)
  ✔ Helper TP-5: Logical expression with literals (0.27979ms)
  ✔ Helper TP-6: Conditional expression with literals (0.399475ms)
  ✔ Helper TP-7: Sequence expression with literals (0.333114ms)
  ✔ Helper TN-7: Update expression with identifier (0.437637ms)
  ✔ Helper TN-1: Identifier is rejected (0.166167ms)
  ✔ Helper TN-2: Unary expression with identifier (0.17908ms)
  ✔ Helper TN-3: Binary expression with identifier (0.162411ms)
  ✔ Helper TN-4: Complex non-literal expressions are rejected (0.155317ms)
  ✔ Helper TN-5: Function calls and member expressions (0.272211ms)
  ✔ Helper TN-6: Null and undefined handling (0.103979ms)
✔ UNSAFE: resolveDefiniteBinaryExpressions (30.750689ms)
▶ UNSAFE: resolveDefiniteMemberExpressions
  ✔ TP-1: String and array indexing with properties (2.843956ms)
  ✔ TP-2: Array literal indexing (2.570431ms)
  ✔ TP-3: String indexing with different positions (2.517684ms)
  ✔ TP-4: Array length property (2.697932ms)
  ✔ TP-5: Mixed literal types in arrays (5.048771ms)
  ✔ TP-6: Non-computed property access with identifier (2.323878ms)
  ✔ TN-1: Do not transform update expressions (0.227527ms)
  ✔ TN-2: Do not transform method calls (callee position) (0.219992ms)
  ✔ TN-3: Do not transform computed properties with variables (0.296165ms)
  ✔ TN-4: Do not transform non-literal objects (0.184115ms)
  ✔ TN-5: Do not transform empty literals (0.147074ms)
  ✔ TN-6: Do not transform complex property expressions (0.168133ms)
  ✔ TN-7: Do not transform out-of-bounds access (handled by sandbox) (1.928799ms)
✔ UNSAFE: resolveDefiniteMemberExpressions (21.761002ms)
▶ UNSAFE: resolveDeterministicConditionalExpressions
  ✔ TP-1: Boolean literals (true/false) (2.418444ms)
  ✔ TP-2: Truthy string literals (2.285077ms)
  ✔ TP-3: Falsy string literal (empty string) (2.208943ms)
  ✔ TP-4: Truthy number literals (2.38236ms)
  ✔ TP-5: Falsy number literal (zero) (2.193694ms)
  ✔ TP-6: Null literal (2.235761ms)
  ✔ TP-7: Nested conditional expressions (single pass) (2.192118ms)
  ✔ TP-8: Complex expressions as branches (2.372767ms)
  ✔ TN-1: Non-literal test expressions (0.397089ms)
  ✔ TN-2: Variable test expressions (0.260944ms)
  ✔ TN-3: Function call test expressions (0.220925ms)
  ✔ TN-4: Binary expression test expressions (0.218607ms)
  ✔ TN-5: Member expression test expressions (0.205399ms)
  ✔ TN-6: Unary expressions (not literals) (0.169703ms)
  ✔ TN-7: Undefined identifier (not literal) (0.138241ms)
✔ UNSAFE: resolveDeterministicConditionalExpressions (20.34554ms)
▶ UNSAFE: resolveEvalCallsOnNonLiterals
  ✔ TP-1: Function call that returns string (3.746199ms)
  ✔ TP-2: Array access returning empty string (2.57003ms)
  ✔ TP-3: Variable reference resolution (2.874472ms)
  ✔ TP-4: Function expression IIFE (2.811779ms)
  ✔ TP-5: Member expression property access (3.372836ms)
  ✔ TP-6: Array index with complex expression (2.924136ms)
  ✔ TN-1: Eval with literal string (already handled by another module) (0.209124ms)
  ✔ TN-2: Non-eval function calls (0.210026ms)
  ✔ TN-3: Eval with multiple arguments (0.12531ms)
  ✔ TN-4: Eval with no arguments (0.120182ms)
  ✔ TN-5: Computed member expression for eval (0.125913ms)
  ✔ TN-6: Eval with non-evaluable expression (1.872511ms)
✔ UNSAFE: resolveEvalCallsOnNonLiterals (21.337991ms)
▶ UNSAFE: resolveFunctionToArray
  ✔ TP-1: Simple function returning array (2.577851ms)
  ✔ TP-2: Function with multiple elements (2.521929ms)
  ✔ TP-3: Arrow function returning array (2.822181ms)
  ✔ TP-4: Function with parameters (ignored) (2.547506ms)
  ✔ TP-5: Multiple variables with array access only (2.649241ms)
  ✔ TN-1: Function call with non-array-access usage (0.432834ms)
  ✔ TP-6: Variable with empty references array (should transform) (2.452674ms)
  ✔ TN-3: Variable not assigned function call (0.321554ms)
  ✔ TN-4: Mixed usage (array access and other) (0.370372ms)
  ✔ TP-7: Function with property access (length is MemberExpression) (5.323956ms)
  ✔ TN-5: Function with method calls (not just property access) (0.393273ms)
  ✔ TN-6: Non-literal init expression (1.891132ms)
✔ UNSAFE: resolveFunctionToArray (24.693991ms)
▶ UNSAFE: resolveInjectedPrototypeMethodCalls
  ✔ TP-1: String prototype method injection (2.88922ms)
  ✔ TP-2: Number prototype method injection (2.585742ms)
  ✔ TP-3: Array prototype method injection (2.525403ms)
  ✔ TP-4: Method with parameters (2.69434ms)
  ✔ TP-5: Multiple calls to same injected method (2.614891ms)
  ✔ TP-6: Identifier assignment to prototype method (2.493301ms)
  ✔ TP-7: Method call with missing arguments resolves to expected result (2.61714ms)
  ✔ TP-8: Arrow function prototype method injection (2.365867ms)
  ✔ TP-9: Arrow function with parameters (2.432927ms)
  ✔ TP-10: Arrow function using closure variable (2.527259ms)
  ✔ TN-1: Non-prototype property assignment (0.593497ms)
  ✔ TN-2: Non-function assignment to prototype (0.423813ms)
  ✔ TN-3: Call to non-injected method (2.638838ms)
  ✔ TN-4: Assignment with non-assignment operator (0.456703ms)
  ✔ TN-5: Complex expression assignment to prototype (0.322979ms)
  ✔ TN-6: Arrow function returning this (may not evaluate safely) (2.379395ms)
✔ UNSAFE: resolveInjectedPrototypeMethodCalls (33.146154ms)
▶ UNSAFE: resolveLocalCalls
  ✔ TP-1: Function declaration (3.02859ms)
  ✔ TP-2: Arrow function (2.852694ms)
  ✔ TP-3: Overwritten builtin (2.794494ms)
  ✔ TP-4: Function expression (2.631773ms)
  ✔ TP-5: Multiple calls to same function (2.479178ms)
  ✔ TP-6: Function returning string (2.285237ms)
  ✔ TN-1: Missing declaration (0.271383ms)
  ✔ TN-2: Skipped builtin (0.182308ms)
  ✔ TN-3: No replacement with undefined (2.040844ms)
  ✔ TN-4: Complex member expression property access (2.475575ms)
  ✔ TP-7: Function call argument with FunctionExpression (6.357334ms)
  ✔ TN-5: Function toString (anti-debugging protection) (0.258654ms)
  ✔ TN-6: Simple wrapper function (handled by safe modules) (0.211824ms)
  ✔ TN-7: Call with ThisExpression argument (4.927939ms)
  ✔ TN-8: Member expression call on empty array (2.145044ms)
✔ UNSAFE: resolveLocalCalls (35.458693ms)
▶ UNSAFE: resolveMinimalAlphabet
  ✔ TP-1: Unary expressions on literals and arrays (19.596563ms)
  ✔ TP-2: Binary expressions with arrays (JSFuck patterns) (5.75093ms)
  ✔ TP-3: Unary expressions on null literal (4.770211ms)
  ✔ TP-4: Binary expressions with string concatenation (5.248931ms)
  ✔ TN-1: Expressions containing ThisExpression should be skipped (7.733384ms)
  ✔ TN-2: Binary expressions with non-plus operators (0.213384ms)
  ✔ TN-3: Unary expressions on numeric literals (0.140565ms)
  ✔ TN-4: Unary expressions on undefined identifier (0.125731ms)
✔ UNSAFE: resolveMinimalAlphabet (43.841408ms)
▶ resolveMemberExpressionsLocalReferences (resolveMemberExpressionsLocalReferences.js)
  ✔ TP-1: Array index access with literal (3.645622ms)
  ✔ TP-2: Object property access with dot notation (2.710224ms)
  ✔ TP-3: Object property access with string literal (2.389058ms)
  ✔ TP-4: Constructor property access (2.530188ms)
  ✔ TN-1: Object computed property with identifier variable (2.233097ms)
  ✔ TN-2: Array index with identifier variable (2.168788ms)
  ✔ TN-3: Function parameter reference (2.235409ms)
  ✔ TN-4: Member expression on left side of assignment (0.339168ms)
  ✔ TN-5: Member expression used as call expression callee (0.315469ms)
  ✔ TN-6: Property with skipped name (length) (0.187977ms)
✔ resolveMemberExpressionsLocalReferences (resolveMemberExpressionsLocalReferences.js) (19.09247ms)
▶ UTILS: evalInVm
  ✔ TP-1: String concatenation (8.096057ms)
  ✔ TP-2: Arithmetic operations (3.318773ms)
  ✔ TP-3: Array literal evaluation (3.259872ms)
  ✔ TP-4: Object literal evaluation (3.213338ms)
  ✔ TP-5: Boolean operations (2.93656ms)
  ✔ TP-6: Array length property (3.026146ms)
  ✔ TP-7: String method calls (3.019115ms)
  ✔ TP-8: Caching behavior - identical code returns same result (2.973883ms)
  ✔ TP-9: Sandbox reuse (3.236571ms)
  ✔ TP-10: Multi-statement code with valid operations (3.124634ms)
  ✔ TP-11: Trap neutralization - infinite while loop (2.982156ms)
  ✔ TP-12: Complex expression evaluation (2.963469ms)
  ✔ TP-14: Debugger statement (neutralized and evaluates successfully) (2.894132ms)
  ✔ TP-13: Split debugger string neutralization works (3.136484ms)
  ✔ TN-1: Non-deterministic function calls (2.975606ms)
  ✔ TN-2: Console object evaluation (3.06787ms)
  ✔ TN-3: Promise objects (bad type) (3.299285ms)
  ✔ TN-4: Invalid syntax (2.856926ms)
  ✔ TN-5: Function calls with side effects (2.872141ms)
  ✔ TN-6: Variable references (undefined) (4.358338ms)
  ✔ TN-7: Complex expressions with timing dependencies (3.097117ms)
✔ UTILS: evalInVm (74.004951ms)
▶ UTILS: areReferencesModified
  ✔ TP-1: Update expression (10.643743ms)
  ✔ TP-2: Direct assignment (2.175998ms)
  ✔ TP-3: Assignment to property (2.060349ms)
  ✔ TP-4: Re-assignment to property (0.959082ms)
  ✔ TP-5: Delete operation on object property (1.109ms)
  ✔ TP-6: Delete operation on array element (0.789336ms)
  ✔ TP-7: For-in loop variable modification (1.503334ms)
  ✔ TP-8: For-of loop variable modification (0.912643ms)
  ✔ TP-9: Array mutating method call (1.113231ms)
  ✔ TP-10: Array sort method call (0.747048ms)
  ✔ TP-11: Object destructuring assignment (1.037541ms)
  ✔ TP-12: Array destructuring assignment (0.629856ms)
  ✔ TP-13: Update expression on member expression (0.506054ms)
  ✔ TN-1: No assignment (0.585056ms)
  ✔ TN-2: Read-only property access (0.479095ms)
  ✔ TN-3: Read-only array access (0.565583ms)
  ✔ TN-4: Non-mutating method calls (0.489305ms)
  ✔ TN-5: For-in loop with different variable (0.942341ms)
  ✔ TN-6: Safe destructuring (different variable) (0.67131ms)
✔ UTILS: areReferencesModified (28.793509ms)
▶ UTILS: createNewNode
  ✔ Literan: String (0.395563ms)
  ✔ Literan: String that starts with ! (0.169447ms)
  ✔ Literal: Number - positive number (0.12178ms)
  ✔ Literal: Number - negative number (0.14974ms)
  ✔ Literal: Number - negative infinity (0.159549ms)
  ✔ Literal: Number - negative zero (0.141992ms)
  ✔ Literal: Number - NOT operator (0.12957ms)
  ✔ Literal: Number - Identifier (0.145668ms)
  ✔ Literal: Boolean (0.1159ms)
  ✔ Array: empty (0.167343ms)
  ✔ Array: populated (0.243645ms)
  ✔ Object: empty (0.155531ms)
  ✔ Object: populated (0.331017ms)
  ✔ Object: populated with BAD_VALUE (0.857911ms)
  ✔ Undefined (0.141216ms)
  ✔ Null (0.127912ms)
  ✔ TODO: Implement Function (0.095151ms) # TODO
  ✔ RegExp (0.187169ms)
  ✔ BigInt (0.16355ms)
  ✔ Symbol with description (0.257706ms)
  ✔ Symbol without description (0.258089ms)
✔ UTILS: createNewNode (5.341694ms)
▶ UTILS: doesDescendantMatchCondition
  ✔ TP-1: Find descendant by type (boolean return) (1.901739ms)
  ✔ TP-2: Find descendant by type (node return) (0.632453ms)
  ✔ TP-3: Find marked descendant (simulating isMarked property) (0.545873ms)
  ✔ TP-4: Multiple nested descendants (0.620403ms)
  ✔ TP-5: Find specific assignment pattern (0.638981ms)
  ✔ TN-1: No matching descendants (0.479247ms)
  ✔ TN-2: Node itself matches condition (0.353397ms)
  ✔ TN-3: Null/undefined input handling (0.214905ms)
  ✔ TN-4: Node with no children (0.469863ms)
  ✔ TN-5: Empty childNodes array (0.146764ms)
✔ UTILS: doesDescendantMatchCondition (6.462874ms)
▶ UTILS: generateHash
  ✔ TP-1: Generate hash for normal string (0.556615ms)
  ✔ TP-2: Generate hash for AST node with .src property (0.216894ms)
  ✔ TP-3: Generate hash for number input (0.142201ms)
  ✔ TP-4: Generate hash for boolean input (0.141768ms)
  ✔ TP-5: Generate hash for empty string (0.144412ms)
  ✔ TP-6: Consistent hashes for identical inputs (0.138483ms)
  ✔ TP-7: Different hashes for different inputs (0.170584ms)
  ✔ TN-1: Handle null input gracefully (0.105607ms)
  ✔ TN-2: Handle undefined input gracefully (0.094732ms)
  ✔ TN-3: Handle object without .src property (0.147408ms)
✔ UTILS: generateHash (2.250903ms)
▶ UTILS: createOrderedSrc
  ✔ TP-1: Re-order nodes (0.769361ms)
  ✔ TP-2: Wrap calls in expressions (0.382112ms)
  ✔ TP-3: Push IIFEs to the end in order (5.473353ms)
  ✔ TP-4: Add dynamic name to IIFEs (1.153944ms)
  ✔ TP-5: Add variable name to IIFEs (0.969489ms)
  ✔ TP-6: Preserve node order (0.689306ms)
  ✔ TP-7: Standalone FEs (0.822553ms)
  ✔ TP-8: Variable declarations with semicolons (0.422237ms)
  ✔ TP-9: Assignment expressions with semicolons (0.502757ms)
  ✔ TP-10: Duplicate node elimination (0.531062ms)
  ✔ TP-11: IIFE dependency ordering with arguments (0.6152ms)
  ✔ TN-1: Empty node array (0.117645ms)
  ✔ TN-2: Single node without reordering (0.320069ms)
  ✔ TN-3: Non-CallExpression and non-FunctionExpression nodes (0.36055ms)
  ✔ TN-4: CallExpression without ExpressionStatement parent (0.306463ms)
  ✔ TN-5: Named function expressions (no renaming needed) (0.50553ms)
✔ UTILS: createOrderedSrc (14.644963ms)
▶ UTILS: getCache
  ✔ TP-1: Retain values for same script hash (0.54083ms)
  ✔ TP-2: Cache invalidation on script hash change (0.18829ms)
  ✔ TP-3: Manual flush preserves script hash (0.158722ms)
  ✔ TP-4: Multiple script hash switches (0.222327ms)
  ✔ TP-5: Cache object mutation persistence (0.172981ms)
  ✔ TN-1: Handle null script hash gracefully (0.173554ms)
  ✔ TN-2: Handle undefined script hash gracefully (0.154358ms)
  ✔ TN-3: Null and undefined should share same fallback cache (0.234709ms)
  ✔ TN-4: Empty string script hash (0.166294ms)
  ✔ TN-5: Flush after multiple hash changes (0.19729ms)
✔ UTILS: getCache (2.613838ms)
▶ UTILS: getCalleeName
  ✔ TP-1: Simple identifier callee (0.513036ms)
  ✔ TP-2: Member expression callee (single level) (0.357331ms)
  ✔ TP-3: Nested member expression callee (0.362395ms)
  ✔ TP-4: Deeply nested member expression (0.352591ms)
  ✔ TP-5: Avoid counting collision between function and literal calls (0.53994ms)
  ✔ TN-1: Literal string method calls return empty (0.325615ms)
  ✔ TN-2: Literal number method calls return empty (0.368707ms)
  ✔ TN-3: ThisExpression method calls return empty (0.343447ms)
  ✔ TN-4: Boolean literal method calls return empty (0.353074ms)
  ✔ TN-5: Logical expression callee returns empty (0.467519ms)
  ✔ TN-6: CallExpression as base object returns empty (0.383287ms)
  ✔ TN-7: Null/undefined input handling (0.142557ms)
  ✔ TN-8: Computed member expression with identifier (0.442163ms)
  ✔ TN-9: Complex callee without name returns empty (0.110871ms)
✔ UTILS: getCalleeName (5.689917ms)
▶ UTILS: getDeclarationWithContext
  ✔ TP-1: Call expression with function declaration (1.336352ms)
  ✔ TP-2: Call expression with function expression (1.14234ms)
  ✔ TP-3: Nested call with FE (0.806881ms)
  ✔ TP-4: Anti-debugging function overwrite (0.938813ms)
  ✔ TP-5: Collect assignments on references (1.045823ms)
  ✔ TP-6: Collect relevant parents for anonymous FE (0.474412ms)
  ✔ TP-7: Node without scriptHash should still work (0.576958ms)
  ✔ TP-8: Node without nodeId should still work (0.601319ms)
  ✔ TN-1: Prevent collection before changes are applied (0.765768ms)
  ✔ TN-2: Handle null input gracefully (0.179777ms)
  ✔ TN-3: Handle undefined input gracefully (0.153504ms)
✔ UTILS: getDeclarationWithContext (8.562957ms)
▶ UTILS: getDescendants
  ✔ TP-1 (0.588145ms)
  ✔ TP-2: Limited scope (0.401901ms)
  ✔ TP-3: Nested function with complex descendants (0.683359ms)
  ✔ TP-4: Object expression with properties (0.520702ms)
  ✔ TP-5: Array expression with elements (0.47146ms)
  ✔ TP-6: Caching behavior - same node returns cached result (0.30926ms)
  ✔ TN-1: No descendants for leaf nodes (0.38283ms)
  ✔ TN-2: Null input returns empty array (0.103222ms)
  ✔ TN-3: Undefined input returns empty array (0.107065ms)
  ✔ TN-4: Node with no childNodes property (0.139435ms)
  ✔ TN-5: Node with empty childNodes array (0.138328ms)
✔ UTILS: getDescendants (4.276505ms)
▶ UTILS: getMainDeclaredObjectOfMemberExpression
  ✔ TP-1: Simple member expression with declared object (0.514234ms)
  ✔ TP-2: Nested member expression finds root identifier (0.395882ms)
  ✔ TP-3: Computed member expression with declared base (0.357425ms)
  ✔ TP-4: Deep nesting finds correct root (0.374555ms)
  ✔ TN-1: Non-MemberExpression input returns the input unchanged (0.484077ms)
  ✔ TN-2: Null input returns null (0.103409ms)
  ✔ TN-3: Undefined input returns null (0.088266ms)
  ✔ TN-4: Member expression with no declNode still returns the object (0.347992ms)
  ✔ TN-5: Non-MemberExpression with declNode returns itself (0.367657ms)
✔ UTILS: getMainDeclaredObjectOfMemberExpression (3.381055ms)
▶ UTILS: getObjType
  ✔ TP-1: Detect Array type (0.206315ms)
  ✔ TP-2: Detect Object type (0.100097ms)
  ✔ TP-3: Detect String type (0.142858ms)
  ✔ TP-4: Detect Number type (0.105915ms)
  ✔ TP-5: Detect Boolean type (0.093672ms)
  ✔ TP-6: Detect Null type (0.12ms)
  ✔ TP-7: Detect Undefined type (0.091952ms)
  ✔ TP-8: Detect Date type (1.275698ms)
  ✔ TP-9: Detect RegExp type (0.169717ms)
  ✔ TP-10: Detect Function type (0.114099ms)
  ✔ TP-11: Detect Arrow Function type (0.097032ms)
  ✔ TP-12: Detect Error type (0.11014ms)
  ✔ TP-13: Detect empty array (0.088597ms)
  ✔ TP-14: Detect empty object (0.086993ms)
  ✔ TP-15: Detect Symbol type (0.105757ms)
  ✔ TP-16: Detect BigInt type (0.113438ms)
✔ UTILS: getObjType (3.509767ms)
▶ UTILS: isNodeInRanges
  ✔ TP-1: Node completely within single range (0.412359ms)
  ✔ TP-2: Node within multiple ranges (first match) (0.255729ms)
  ✔ TP-3: Node within multiple ranges (second match) (0.299724ms)
  ✔ TP-4: Node exactly matching range boundaries (0.285797ms)
  ✔ TP-5: Large range containing small node (0.456079ms)
  ✔ TN-1: Node extends beyond range end (0.296719ms)
  ✔ TN-2: Node starts before range start (0.263482ms)
  ✔ TN-3: Empty ranges array (0.397636ms)
  ✔ TN-4: Node range partially overlapping but not contained (0.348211ms)
✔ UTILS: isNodeInRanges (3.396076ms)
▶ UTILS: Sandbox
  ✔ TP-1: Basic code execution (2.451612ms)
  ✔ TP-2: String operations (2.401304ms)
  ✔ TP-3: Array operations (2.418146ms)
  ✔ TP-4: Object operations (2.437737ms)
  ✔ TP-5: Multiple executions on same sandbox (2.321046ms)
  ✔ TP-6: Deterministic behavior - Math.random is deleted (2.273032ms)
  ✔ TP-7: Deterministic behavior - Date is deleted (2.188094ms)
  ✔ TP-8: Blocked API - WebAssembly is undefined (2.279337ms)
  ✔ TP-9: Blocked API - fetch is undefined (2.314507ms)
  ✔ TP-10: isReference method correctly identifies VM References (2.248556ms)
  ✔ TN-1: isReference returns false for null (2.211029ms)
  ✔ TN-2: isReference returns false for undefined (2.214006ms)
  ✔ TN-3: isReference returns false for regular objects (2.187473ms)
✔ UTILS: Sandbox (30.632443ms)
▶ Processors tests: Augmented Array
  ✔ TP-1: Complex IIFE with mixed array elements (15.032366ms)
  ✔ TP-2: Simple array with single shift (5.488466ms)
  ✔ TP-3: Array with zero shifts (no change) (4.980197ms)
  ✔ TP-4: Array with larger shift count (3.689356ms)
  ✔ TN-1: IIFE with non-literal shift count (1.102862ms)
  ✔ TN-2: IIFE with insufficient arguments (0.872471ms)
  ✔ TN-3: IIFE with non-identifier array argument (0.994827ms)
  ✔ TN-4: Non-IIFE function call (0.887472ms)
  ✔ TN-5: Invalid shift count (NaN) (0.749271ms)
  ✔ TN-9: Function passed to IIFE (function not self-modifying) (1.12867ms)
  ✔ TP-5: Arrow function IIFE (3.426575ms)
  ✔ TP-6: Shift count larger than array length (2.916729ms)
  ✔ TN-10: Arrow function without parentheses around parameters (0.481152ms)
  ✔ TN-11: Negative shift count (0.54086ms)
  ✔ TN-12: IIFE with complex array manipulation that cannot be resolved (2.916434ms)
✔ Processors tests: Augmented Array (47.023893ms)
▶ Processors tests: Caesar Plus
  ﹣ TP-1: FIX ME (0.090667ms) # SKIP
✔ Processors tests: Caesar Plus (0.199238ms)
▶ Processors tests: Function to Array
  ✔ TP-1: Independent call (3.977648ms)
  ✔ TP-2: IIFE (3.341942ms)
  ✔ TP-3: Arrow function returning array (4.522859ms)
  ✔ TP-4: Multiple variables with array access only (3.261904ms)
  ✔ TN-1: Function called multiple times without assignment (0.450471ms)
  ✔ TN-2: Mixed usage (array access and other) (0.479656ms)
  ✔ TN-3: Variable not assigned function call (0.334133ms)
✔ Processors tests: Function to Array (16.603813ms)
▶ Processors tests: Obfuscator.io
  ✔ TP-1 (1.408265ms)
  ✔ TP-2 (0.879333ms)
✔ Processors tests: Obfuscator.io (2.389295ms)
▶ Samples tests
  ✔ Deobfuscate sample: JSFuck (164.63903ms)
  ✔ Deobfuscate sample: Ant & Cockroach (249.329913ms)
  ✔ Deobfuscate sample: New Function IIFE (105.227188ms)
  ✔ Deobfuscate sample: Hunter (207.630495ms)
  ✔ Deobfuscate sample: _$_ (212.715389ms)
  ✔ Deobfuscate sample: Prototype Calls (294.508547ms)
  ﹣ TODO: FIX Deobfuscate sample: Caesar+ (0.073017ms) # SKIP
  ✔ Deobfuscate sample: eval(Ox$ (1090.702209ms)
  ✔ Deobfuscate sample: Obfuscator.io (5284.88855ms)
  ✔ Deobfuscate sample: $s (4121.069944ms)
  ✔ Deobfuscate sample: Local Proxies (6877.523758ms)
✔ Samples tests (18610.686238ms)
▶ parseArgs tests
  ✔ TP-1: Defaults (6.90782ms)
  ✔ TP-2: All on - short (1.489652ms)
  ✔ TP-3: All on - full (0.784386ms)
  ✔ TP-4: Custom outputFilename split (0.657359ms)
  ✔ TP-5: Custom outputFilename equals (0.527724ms)
  ✔ TP-6: Custom outputFilename full (0.640214ms)
  ✔ TP-7: Max iterations short equals (0.594535ms)
  ✔ TP-8: Max iterations short split (0.683154ms)
  ✔ TP-9: Max iterations long equals (1.034759ms)
  ✔ TP-10: Max iterations long split (0.902178ms)
✔ parseArgs tests (16.998637ms)
ℹ tests 763
ℹ suites 64
ℹ pass 757
ℹ fail 0
ℹ cancelled 0
ℹ skipped 4
ℹ todo 2
ℹ duration_ms 18915.563441

</details>

<details>

<summary> flast test suite </summary>

❯ npm run test

> flast@2.2.5 test
> node --test

▶ Arborist tests
  ✔ Verify node replacement works as expected (8.37042ms)
  ✔ Verify the root node replacement works as expected (0.759019ms)
  ✔ Verify only the root node is replaced (0.68237ms)
  ✔ Verify node deletion works as expected (1.977147ms)
  ✔ Verify the correct node is targeted for deletion (1.034456ms)
  ✔ Verify a valid script can be used to initialize an arborist instance (0.645956ms)
  ✔ Verify a valid AST array can be used to initialize an arborist instance (0.51667ms)
  ✔ Verify invalid changes are not applied (1.03896ms)
  ✔ Verify comments aren't duplicated when replacing the root node (1.242921ms)
  ﹣ FIX: Verify comments are kept when replacing a node (0.281187ms) # SKIP
✔ Arborist tests (17.684101ms)
▶ Arborist edge case tests
  ✔ Preserves comments when replacing a non-root node (0.997875ms)
  ✔ Deleting the only element in an array leaves parent valid (0.380847ms)
  ✔ Multiple changes in a single pass (replace and delete siblings) (0.624005ms)
  ✔ Deeply nested node replacement (1.013392ms)
  ✔ Multiple comments on a node being deleted (0.649191ms)
  ✔ Marking the same node for deletion and replacement only applies one change (0.39339ms)
  ✔ AST is still valid and mutable after applyChanges (1.023206ms)
✔ Arborist edge case tests (5.316222ms)
▶ Functionality tests
  ✔ Verify the code breakdown generates the expected nodes by checking the properties of the generated ASTNodes (9.051431ms)
  ✔ Verify the expected functions and classes can be imported (0.416267ms)
  ✔ Verify the code breakdown generates the expected nodes by checking the number of nodes for each expected type (1.163723ms)
  ✔ Verify the AST can be parsed and regenerated into the same code (1.314485ms)
  ✔ Verify generateFlatAST's detailed option works as expected (1.886301ms)
  ✔ Verify a script is parsed in "sloppy mode" if strict mode is restricting parsing (0.946892ms)
  ✔ Verify a script is only parsed in its selected sourceType (0.816794ms)
  ✔ Verify generateFlatAST doesn't throw an exception for invalid code (1.014139ms)
✔ Functionality tests (20.588201ms)
▶ Parsing tests
  ✔ Verify the function-expression-name scope is always replaced with its child scope (10.883892ms)
  ✔ Verify declNode references the local declaration correctly (1.649555ms)
  ✔ Verify a function's identifier isn't treated as a reference (0.685738ms)
  ✔ Verify proper handling of class properties (1.92297ms)
  ✔ Verify the type map is generated accurately (1.011792ms)
  ✔ Verify node relations are parsed correctly (1.139882ms)
  ✔ Verify the module scope is ignored (0.563203ms)
  ✔ Verify the lineage is correct (0.743533ms)
  ✔ Verify null childNodes are correctly parsed (0.561948ms)
  ✔ Verify all identifiers are referenced correctly (0.82796ms)
✔ Parsing tests (21.215143ms)
▶ Utils tests: treeModifier
  ✔ Verify treeModifier sets a generic function name (0.542236ms)
  ✔ Verify treeModifier sets the function's name properly (0.138181ms)
✔ Utils tests: treeModifier (1.477427ms)
▶ Utils tests: applyIteratively
  ✔ Verify applyIteratively cannot remove the root node without replacing it (5.861221ms)
  ✔ Verify applyIteratively catches a critical exception (0.776551ms)
  ✔ Verify applyIteratively works as expected (3.213094ms)
✔ Utils tests: applyIteratively (10.036826ms)
▶ Utils tests: logger
  ✔ Verify logger sets the log level to DEBUG properly (0.266163ms)
  ✔ Verify logger sets the log level to NONE properly (0.221948ms)
  ✔ Verify logger sets the log level to LOG properly (0.16037ms)
  ✔ Verify logger sets the log level to ERROR properly (0.13716ms)
  ✔ Verify logger sets the log function properly (0.203891ms)
  ✔ Verify logger throws an error when setting an unknown log level (0.34863ms)
✔ Utils tests: logger (1.617188ms)
ℹ tests 46
ℹ suites 7
ℹ pass 45
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
ℹ duration_ms 427.584721

</details>