### PR TITLE
Replace stack based tree traversal in extractNodesFromRoot with a Visitor pattern.

### DIFF
--- a/src/flast.js
+++ b/src/flast.js
@@ -162,8 +162,12 @@ function extractNodesFromRoot(rootNode, opts) {
 				node.lineage.push(node.scope.scopeId);
 			}
 		}
-		// Add a getter for the node's source code
-		if (opts.includeSrc && !node.src) node.src = rootNode.src.substring(node.start,node.end);
+		// Avoid using a getter with a closure around source here, as the 
+		// memory requirement for a function per node is far greater than using 
+		// a string reference for sufficiently large AST Trees 
+		// (~2.4 nodes for 3 Gib).
+		if (opts.includeSrc && !node.src) 
+			node.src = rootNode.src.substring(node.start,node.end);
 	}
 	if (opts.detailed) {
 		const identifiers = typeMap.Identifier || [];

--- a/src/flast.js
+++ b/src/flast.js
@@ -105,72 +105,93 @@ function generateRootNode(inputCode, opts = {}) {
 }
 
 /**
+ * @param {object} opts
+ * @param {ASTNode} rootNode
+ * @param {{number: ASTScope}} scopes
+ * @param {number} nodeId
+ * @param {ASTNode} node
+ * @return {ASTNode}
+ */
+function parseNode (opts, rootNode, scopes, nodeId, node) {
+	if (node.nodeId) return;
+	node.childNodes = node.childNodes || [];
+	const childrenLoc = {}; // Store the location of child nodes to sort them by order
+	node.parentKey = node.parentKey || '';	// Make sure parentKey exists
+	// Iterate over all keys of the node to find child nodes
+	const keys = Object.keys(node);
+	for (let i = 0; i < keys.length; i++) {
+		const key = keys[i];
+		if (excludedParentKeys.includes(key)) continue;
+		const content = node[key];
+		if (content && typeof content === 'object') {
+			// Sort each child node by its start position
+			// and set the parentNode and parentKey attributes
+			if (Array.isArray(content)) {
+				for (let j = 0; j < content.length; j++) {
+					const childNode = content[j];
+					if (!childNode) continue;
+					childNode.parentNode = node;
+					childNode.parentKey = key;
+					childrenLoc[childNode.start] = childNode;
+				}
+			} else {
+				content.parentNode = node;
+				content.parentKey = key;
+				childrenLoc[content.start] = content;
+			}
+		}
+	}
+	// Add the child nodes to top of the stack and populate the node's childNodes array
+	node.childNodes.push(...Object.values(childrenLoc));
+
+	node.nodeId = nodeId;
+	if (opts.detailed) {
+		node.scope = scopes[node.scopeId] || node.parentNode?.scope;
+		node.lineage = [...node.parentNode?.lineage || []];
+		if (!node.lineage.includes(node.scope.scopeId)) {
+			node.lineage.push(node.scope.scopeId);
+		}
+	}
+	// Avoid using a getter with a closure around source here, as the 
+	// memory requirement for a function per node is far greater than using 
+	// a string reference for sufficiently large AST Trees 
+	// (~2.4 nodes for 3 Gib).
+	if (opts.includeSrc && !node.src) 
+		node.src = rootNode.src.substring(node.start,node.end);
+	return node;
+}
+
+/**
  * @param rootNode
  * @param opts
  * @return {ASTNode[]}
  */
 function extractNodesFromRoot(rootNode, opts) {
 	opts = {...generateFlatASTDefaultOptions, ...opts};
-	let nodeId = 0;
 	const typeMap = {};
 	const allNodes = [];
 	const scopes = opts.detailed ? getAllScopes(rootNode) : {};
 
-	function parseNode (node) {
-		if (node.nodeId) return;
-		node.childNodes = node.childNodes || [];
-		const childrenLoc = {};  								// Store the location of child nodes to sort them by order
-		node.parentKey = node.parentKey || '';	// Make sure parentKey exists
-		// Iterate over all keys of the node to find child nodes
-		const keys = Object.keys(node);
-		for (let i = 0; i < keys.length; i++) {
-			const key = keys[i];
-			if (excludedParentKeys.includes(key)) continue;
-			const content = node[key];
-			if (content && typeof content === 'object') {
-				// Sort each child node by its start position
-				// and set the parentNode and parentKey attributes
-				if (Array.isArray(content)) {
-					for (let j = 0; j < content.length; j++) {
-						const childNode = content[j];
-						if (!childNode) continue;
-						childNode.parentNode = node;
-						childNode.parentKey = key;
-						childrenLoc[childNode.start] = childNode;
-					}
-				} else {
-					content.parentNode = node;
-					content.parentKey = key;
-					childrenLoc[content.start] = content;
-				}
+	let nodeId = 0;
+	let visitor = rootNode;
+	while (visitor) {
+		if(!visitor.childNodes){
+			allNodes.push(parseNode(opts, rootNode, scopes, nodeId, visitor));
+			nodeId++;
+			typeMap[visitor.type] = typeMap[visitor.type] || [];
+			typeMap[visitor.type].push(visitor);
+		}
+		let parsedAllChildNodes = true;
+		for(let i = 0; i < visitor.childNodes.length; ++i){
+			if(!visitor.childNodes[i].nodeId){
+				parsedAllChildNodes = false;
+				visitor = visitor.childNodes[i];
+				break;
 			}
 		}
-		// Add the child nodes to top of the stack and populate the node's childNodes array
-		node.childNodes.push(...Object.values(childrenLoc));
-
-		allNodes.push(node);
-		node.nodeId = nodeId++;
-		typeMap[node.type] = typeMap[node.type] || [];
-		typeMap[node.type].push(node);
-		if (opts.detailed) {
-			node.scope = scopes[node.scopeId] || node.parentNode?.scope;
-			node.lineage = [...node.parentNode?.lineage || []];
-			if (!node.lineage.includes(node.scope.scopeId)) {
-				node.lineage.push(node.scope.scopeId);
-			}
+		if(parsedAllChildNodes){
+			visitor = visitor.parentNode;
 		}
-		// Avoid using a getter with a closure around source here, as the 
-		// memory requirement for a function per node is far greater than using 
-		// a string reference for sufficiently large AST Trees 
-		// (~2.4 nodes for 3 Gib).
-		if (opts.includeSrc && !node.src) 
-			node.src = rootNode.src.substring(node.start,node.end);
-		return childrenLoc;
-	}
-
-	const stack = [rootNode];
-	while (stack.length) {
-		stack.unshift(...Object.values(parseNode(stack.shift())));
 	}
 
 	if (opts.detailed) {

--- a/src/flast.js
+++ b/src/flast.js
@@ -39,15 +39,6 @@ const generateFlatASTDefaultOptions = {
 };
 
 /**
- * Return a function which retrieves a node's source on demand
- * @param {string} src
- * @returns {function(number, number): string}
- */
-function createSrcClosure(src) {
-	return function(start, end) {return src.slice(start, end);};
-}
-
-/**
  * @param {string} inputCode
  * @param {object} opts Optional changes to behavior. See generateFlatASTDefaultOptions for available options.
  * @return {ASTNode[]} An array of flattened AST
@@ -96,13 +87,13 @@ function generateRootNode(inputCode, opts = {}) {
 	let rootNode;
 	try {
 		rootNode = parseCode(inputCode, parseOpts);
-		if (opts.includeSrc) rootNode.srcClosure = createSrcClosure(inputCode);
+		if (opts.includeSrc) rootNode.src = inputCode;
 	} catch (e) {
 		// If any parse error occurs and alternateSourceTypeOnFailure is set, try 'script' mode
 		if (opts.alternateSourceTypeOnFailure) {
 			try {
 				rootNode = parseCode(inputCode, {...parseOpts, sourceType: 'script'});
-				if (opts.includeSrc) rootNode.srcClosure = createSrcClosure(inputCode);
+				if (opts.includeSrc) rootNode.src = inputCode;
 			} catch (e2) {
 				logger.debug('Failed to parse as module and script:', e, e2);
 			}
@@ -172,9 +163,7 @@ function extractNodesFromRoot(rootNode, opts) {
 			}
 		}
 		// Add a getter for the node's source code
-		if (opts.includeSrc && !node.src) Object.defineProperty(node, 'src', {
-			get() {return rootNode.srcClosure(node.start, node.end);},
-		});
+		if (opts.includeSrc && !node.src) node.src = rootNode.src.substring(node.start,node.end);
 	}
 	if (opts.detailed) {
 		const identifiers = typeMap.Identifier || [];

--- a/src/flast.js
+++ b/src/flast.js
@@ -174,23 +174,20 @@ function extractNodesFromRoot(rootNode, opts) {
 
 	let nodeId = 0;
 	let visitor = rootNode;
+	const lastParsed = {};
 	while (visitor) {
 		if(!visitor.childNodes){
-			allNodes.push(parseNode(opts, rootNode, scopes, nodeId, visitor));
-			nodeId++;
+			allNodes.push(parseNode(opts, rootNode, scopes, nodeId++, visitor));
 			typeMap[visitor.type] = typeMap[visitor.type] || [];
 			typeMap[visitor.type].push(visitor);
+			lastParsed[visitor.nodeId] = 0;
 		}
-		let parsedAllChildNodes = true;
-		for(let i = 0; i < visitor.childNodes.length; ++i){
-			if(!visitor.childNodes[i].nodeId){
-				parsedAllChildNodes = false;
-				visitor = visitor.childNodes[i];
-				break;
-			}
-		}
-		if(parsedAllChildNodes){
+		let visitorId = visitor.nodeId;
+		if(lastParsed[visitorId] < visitor.childNodes.length){
+			visitor = visitor.childNodes[lastParsed[visitorId]++];
+		}else{
 			visitor = visitor.parentNode;
+			delete lastParsed[visitorId];
 		}
 	}
 

--- a/src/flast.js
+++ b/src/flast.js
@@ -116,10 +116,8 @@ function extractNodesFromRoot(rootNode, opts) {
 	const allNodes = [];
 	const scopes = opts.detailed ? getAllScopes(rootNode) : {};
 
-	const stack = [rootNode];
-	while (stack.length) {
-		const node = stack.shift();
-		if (node.nodeId) continue;
+	function parseNode (node) {
+		if (node.nodeId) return;
 		node.childNodes = node.childNodes || [];
 		const childrenLoc = {};  								// Store the location of child nodes to sort them by order
 		node.parentKey = node.parentKey || '';	// Make sure parentKey exists
@@ -148,7 +146,6 @@ function extractNodesFromRoot(rootNode, opts) {
 			}
 		}
 		// Add the child nodes to top of the stack and populate the node's childNodes array
-		stack.unshift(...Object.values(childrenLoc));
 		node.childNodes.push(...Object.values(childrenLoc));
 
 		allNodes.push(node);
@@ -168,7 +165,14 @@ function extractNodesFromRoot(rootNode, opts) {
 		// (~2.4 nodes for 3 Gib).
 		if (opts.includeSrc && !node.src) 
 			node.src = rootNode.src.substring(node.start,node.end);
+		return childrenLoc;
 	}
+
+	const stack = [rootNode];
+	while (stack.length) {
+		stack.unshift(...Object.values(parseNode(stack.shift())));
+	}
+
 	if (opts.detailed) {
 		const identifiers = typeMap.Identifier || [];
 		const scopeVarMaps = buildScopeVarMaps(scopes);


### PR DESCRIPTION
Looked into the stack being a potential source for the OOM issue I've been hunting down. It didn't end up meaningfully affecting the memory footprint of the function, but I still think this a cleaner solution than the stack approach.

Happy to split the PR into two, if only submitting the basic refactor is preferred over changing the traversal as well.

<details>

<summary> flast test suite </summary>

❯ npm run test

> flast@2.2.5 test
> node --test

▶ Arborist tests
  ✔ Verify node replacement works as expected (15.813212ms)
  ✔ Verify the root node replacement works as expected (1.256445ms)
  ✔ Verify only the root node is replaced (1.076036ms)
  ✔ Verify node deletion works as expected (3.028453ms)
  ✔ Verify the correct node is targeted for deletion (1.49175ms)
  ✔ Verify a valid script can be used to initialize an arborist instance (1.026975ms)
  ✔ Verify a valid AST array can be used to initialize an arborist instance (0.775022ms)
  ✔ Verify invalid changes are not applied (1.669411ms)
  ✔ Verify comments aren't duplicated when replacing the root node (1.899145ms)
  ﹣ FIX: Verify comments are kept when replacing a node (0.434238ms) # SKIP
✔ Arborist tests (30.279681ms)
▶ Arborist edge case tests
  ✔ Preserves comments when replacing a non-root node (1.601292ms)
  ✔ Deleting the only element in an array leaves parent valid (0.603422ms)
  ✔ Multiple changes in a single pass (replace and delete siblings) (1.145907ms)
  ✔ Deeply nested node replacement (1.599283ms)
  ✔ Multiple comments on a node being deleted (1.032956ms)
  ✔ Marking the same node for deletion and replacement only applies one change (0.655853ms)
  ✔ AST is still valid and mutable after applyChanges (0.677051ms)
✔ Arborist edge case tests (7.685087ms)
▶ Functionality tests
  ✔ Verify the code breakdown generates the expected nodes by checking the properties of the generated ASTNodes (9.206221ms)
  ✔ Verify the expected functions and classes can be imported (1.541532ms)
  ✔ Verify the code breakdown generates the expected nodes by checking the number of nodes for each expected type (2.167833ms)
  ✔ Verify the AST can be parsed and regenerated into the same code (2.548414ms)
  ✔ Verify generateFlatAST's detailed option works as expected (3.747265ms)
  ✔ Verify a script is parsed in "sloppy mode" if strict mode is restricting parsing (1.685075ms)
  ✔ Verify a script is only parsed in its selected sourceType (1.427216ms)
  ✔ Verify generateFlatAST doesn't throw an exception for invalid code (1.122795ms)
✔ Functionality tests (25.144802ms)
▶ Parsing tests
  ✔ Verify the function-expression-name scope is always replaced with its child scope (16.209266ms)
  ✔ Verify declNode references the local declaration correctly (2.301971ms)
  ✔ Verify a function's identifier isn't treated as a reference (1.036623ms)
  ✔ Verify proper handling of class properties (3.206558ms)
  ✔ Verify the type map is generated accurately (1.671665ms)
  ✔ Verify node relations are parsed correctly (2.005444ms)
  ✔ Verify the module scope is ignored (1.023004ms)
  ✔ Verify the lineage is correct (1.233648ms)
  ✔ Verify null childNodes are correctly parsed (0.998356ms)
  ✔ Verify all identifiers are referenced correctly (1.476742ms)
✔ Parsing tests (33.144654ms)
▶ Utils tests: treeModifier
  ✔ Verify treeModifier sets a generic function name (0.832762ms)
  ✔ Verify treeModifier sets the function's name properly (0.21362ms)
✔ Utils tests: treeModifier (2.337748ms)
▶ Utils tests: applyIteratively
  ✔ Verify applyIteratively cannot remove the root node without replacing it (9.089977ms)
  ✔ Verify applyIteratively catches a critical exception (1.120168ms)
  ✔ Verify applyIteratively works as expected (5.020163ms)
✔ Utils tests: applyIteratively (15.516357ms)
▶ Utils tests: logger
  ✔ Verify logger sets the log level to DEBUG properly (0.434717ms)
  ✔ Verify logger sets the log level to NONE properly (0.335663ms)
  ✔ Verify logger sets the log level to LOG properly (0.235369ms)
  ✔ Verify logger sets the log level to ERROR properly (0.219354ms)
  ✔ Verify logger sets the log function properly (0.316249ms)
  ✔ Verify logger throws an error when setting an unknown log level (0.520079ms)
✔ Utils tests: logger (2.492552ms)
ℹ tests 46
ℹ suites 7
ℹ pass 45
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
ℹ duration_ms 411.434058


</details>


<details>

<summary> restringer test suite </summary>

❯ npm run test

> restringer@2.1.0 test
> node --test --trace-warnings --no-node-snapshot

▶ Deobfuscation tests
  ✔ Augmented Array Replacements (43.743501ms)
  ✔ Compute definite binary expressions (5.429703ms)
  ✔ Don't replace modified member expressions (3.600798ms)
  ✔ Don't replace member expressions on empty arrays (1.668709ms)
  ﹣ TODO: Fix. Normalize Script Correctly (0.142342ms) # SKIP
  ✔ Parse template literals into string literals (3.745067ms)
  ✔ Remove nested block statements (4.093394ms)
  ✔ Remove redundant logical expressions (17.085564ms)
  ✔ Remove redundant not operators (33.297138ms)
  ✔ Replace augmented function with corrected array (32.745004ms)
  ✔ Replace deterministic if statement (6.376827ms)
  ✔ Replace function calls with unwrapped identifier - arrow functions (9.045522ms)
  ✔ Replace function calls with unwrapped identifier - function declarations (8.245936ms)
  ✔ Replace function evals - eval(string) (2.898987ms)
  ✔ Replace function evals in call expressions - eval(string)(args) (8.625885ms)
  ✔ Replace identifier with fixed assigned value (12.16125ms)
  ✔ Replace literal proxies (5.377084ms)
  ✔ Replace local calls proxy - arrow functions (20.240728ms)
  ﹣ TODO: FIX Replace local calls proxy - function declarations (0.09077ms) # SKIP
  ✔ Replace local calls with values - immediate (1.436925ms)
  ✔ Replace local calls with values - nested (10.955248ms)
  ✔ Replace local member expressions property reference with value (13.422234ms)
  ✔ Replace local member expressions proxy - chained proxies (8.324841ms)
  ✔ Replace local member expressions proxy - member assignment (2.092724ms)
  ✔ Replace member expression references with values (12.470749ms)
  ✔ Replace reference proxy (8.810827ms)
  ✔ Replace wrapped functions with return statement (5.264788ms)
  ✔ Resolve builtin call expressions: btoa & atob (3.63779ms)
  ✔ Resolve definite member expressions (3.700491ms)
  ✔ Resolve deterministic conditional expressions (6.973574ms)
  ✔ Resolve directly assigned member expressions (5.408568ms)
  ✔ Resolve external references with context (13.236503ms)
  ✔ Resolve function constructor calls (8.775295ms)
  ✔ Resolve injected prototype method calls (10.237546ms)
  ✔ Resolve member expression local references with unary expressions correctly (12.556125ms)
  ✔ Resolve member expression references with context (9.217801ms)
  ✔ Unwrap function shells (1.663614ms)
  ✔ Verify correct context for function declaration (9.926287ms)
  ✔ Verify correct context for function variable (6.373194ms)
  ✔ Verify correct replacement of member expressions with literals (6.058107ms)
  ✔ Verify random values remain untouched (10.953361ms)
✔ Deobfuscation tests (394.870514ms)
▶ Functionality tests
  ✔ Set max iterations (29.410527ms)
  ✔ REstringer.__version__ is populated (0.262642ms)
✔ Functionality tests (32.012639ms)
▶ SAFE: removeRedundantBlockStatements
  ✔ TP-1 (18.12412ms)
  ✔ TP-2 (3.395853ms)
  ✔ TP-3 (4.788609ms)
  ✔ TP-4 (3.97641ms)
✔ SAFE: removeRedundantBlockStatements (33.281977ms)
▶ SAFE: normalizeComputed
  ✔ TP-1: Convert valid string identifiers to dot notation (3.728217ms)
  ✔ TP-2: Convert object properties with valid identifiers (5.410342ms)
  ✔ TP-3: Convert class method definitions with valid identifiers (4.721924ms)
  ✔ TN-1: Do not convert invalid identifiers (1.047759ms)
  ✔ TN-2: Do not convert numeric indices but convert valid string (1.655912ms)
✔ SAFE: normalizeComputed (17.520487ms)
▶ SAFE: normalizeEmptyStatements
  ✔ TP-1: Remove standalone empty statements (1.976428ms)
  ✔ TP-2: Remove empty statements in blocks (1.574113ms)
  ✔ TN-1: Preserve empty statements in for-loops (3.195322ms)
  ✔ TN-2: Preserve empty statements in while-loops (1.090195ms)
  ✔ TN-3: Preserve empty statements in if-statements (0.996577ms)
  ✔ TN-4: Preserve empty statements in do-while loops (0.892767ms)
  ✔ TN-5: Preserve empty statements in for-in loops (0.59798ms)
✔ SAFE: normalizeEmptyStatements (10.879633ms)
▶ SAFE: parseTemplateLiteralsIntoStringLiterals
  ✔ TP-1: Convert template literal with string expression (2.76546ms)
  ✔ TP-2: Convert template literal with multiple expressions (1.104169ms)
  ✔ TP-3: Convert template literal with no expressions (0.682938ms)
  ✔ TP-4: Convert template literal with boolean and number expressions (0.922047ms)
  ✔ TP-5: Convert empty template literal (0.903364ms)
  ✔ TN-1: Do not convert template literal with variable expression (0.564785ms)
  ✔ TN-2: Do not convert template literal with function call expression (0.584284ms)
  ✔ TN-3: Do not convert template literal with mixed literal and non-literal expressions (0.660571ms)
✔ SAFE: parseTemplateLiteralsIntoStringLiterals (8.711846ms)
▶ SAFE: rearrangeSequences
  ✔ TP-1: Split sequenced calls to standalone expressions (2.62554ms)
  ✔ TP-2: Split sequenced calls to standalone expressions in if-statements (2.163697ms)
  ✔ TP-3: Split sequenced calls in if-statements to cascading if-statements (1.155257ms)
  ✔ TP-4: Split sequenced calls in nested if-statements to cascading if-statements (1.17263ms)
  ✔ TP-5: Split sequences with more than three expressions (1.465809ms)
  ✔ TP-6: Split sequences in if condition with else clause (1.249073ms)
  ✔ TN-1: Do not transform single expression returns (0.508883ms)
  ✔ TN-2: Do not transform single expression if conditions (0.441437ms)
  ✔ TN-3: Do not transform non-sequence expressions (0.717586ms)
✔ SAFE: rearrangeSequences (12.186077ms)
▶ SAFE: rearrangeSwitches
  ✔ TP-1: Complex switch with multiple cases and return statement (9.292508ms)
  ✔ TP-2: Simple switch with sequential cases (7.296366ms)
  ✔ TP-3: Switch with default case (3.289733ms)
  ✔ TP-4: Switch starting with non-initial case via default (6.130043ms)
  ✔ TN-1: Do not transform switch without literal discriminant initialization (1.195736ms)
  ✔ TP-5: Transform switch but stop at multiple assignments to discriminant (1.726605ms)
  ✔ TN-2: Do not transform switch with non-literal case value (0.660829ms)
✔ SAFE: rearrangeSwitches (30.648597ms)
▶ SAFE: removeDeadNodes
  ✔ TP-1 (1.423803ms)
✔ SAFE: removeDeadNodes (1.576908ms)
▶ SAFE: replaceCallExpressionsWithUnwrappedIdentifier
  ✔ TP-1: Replace call expression with identifier behind an arrow function (1.183571ms)
  ✔ TP-2: Replace call expression with identifier behind a function declaration (0.717792ms)
  ✔ TP-3: Replace call expression with function expression assigned to variable (2.16804ms)
  ✔ TP-4: Replace call expression with arrow function using block statement (1.207722ms)
  ✔ TP-5: Replace call expression returning parameterless call (0.742294ms)
  ✔ TN-1: Do not replace function returning call expression with arguments (0.403837ms)
  ✔ TN-2: Do not replace function with multiple statements (0.455893ms)
  ✔ TN-3: Do not replace function with no return statement (0.573071ms)
  ✔ TN-4: Do not replace non-function callee (0.594043ms)
✔ SAFE: replaceCallExpressionsWithUnwrappedIdentifier (8.518247ms)
▶ SAFE: replaceEvalCallsWithLiteralContent
  ✔ TP-1: Replace eval call with the code parsed from the argument string (1.550857ms)
  ✔ TP-2: Replace eval call with a block statement with multiple expression statements (0.978288ms)
  ✔ TP-3: Replace eval call with the code in a return statement (0.977923ms)
  ✔ TP-4: Replace eval call wrapped in a call expression (1.012765ms)
  ✔ TP-5: Replace eval call wrapped in a binary expression (1.195316ms)
  ✔ TP-6: Unwrap expression statement from replacement where needed (0.601157ms)
  ✔ TP-7: Replace eval with single expression in conditional (0.574988ms)
  ✔ TP-8: Replace eval with function declaration (0.856965ms)
  ✔ TN-1: Do not replace eval with non-literal argument (0.334266ms)
  ✔ TN-2: Do not replace non-eval function calls (0.222474ms)
  ✔ TN-3: Do not replace eval with invalid syntax (0.997224ms)
  ✔ TN-4: Do not replace eval with no arguments (0.282841ms)
✔ SAFE: replaceEvalCallsWithLiteralContent (10.083643ms)
▶ SAFE: replaceFunctionShellsWithWrappedValue
  ✔ TP-1: Replace references with identifier (1.245465ms)
  ✔ TP-2: Replace function returning literal number (0.753178ms)
  ✔ TP-3: Replace function returning literal string (0.583971ms)
  ✔ TP-4: Replace function returning boolean literal (0.73596ms)
  ✔ TP-5: Replace multiple calls to same function (0.737442ms)
  ✔ TN-1: Should not replace literals 1 (0.452423ms)
  ✔ TN-2: Should not replace literals 2 (0.434759ms)
  ✔ TN-3: Do not replace function with multiple statements (0.400314ms)
  ✔ TN-4: Do not replace function with no return statement (0.328597ms)
  ✔ TN-5: Do not replace function returning complex expression (0.371185ms)
  ✔ TN-6: Do not replace function used as callback (0.453007ms)
✔ SAFE: replaceFunctionShellsWithWrappedValue (6.997455ms)
▶ SAFE: replaceFunctionShellsWithWrappedValueIIFE
  ✔ TP-1: Replace with wrapped value in-place (0.874948ms)
  ✔ TP-2: Replace IIFE returning literal number (0.663833ms)
  ✔ TP-3: Replace IIFE returning literal string (0.604908ms)
  ✔ TP-4: Replace IIFE returning boolean literal (0.558052ms)
  ✔ TP-5: Replace IIFE returning identifier (0.663507ms)
  ✔ TP-6: Replace multiple IIFEs in expression (0.810199ms)
  ✔ TN-1: Do not replace IIFE with arguments (0.416203ms)
  ✔ TN-2: Do not replace IIFE with multiple statements (0.42173ms)
  ✔ TN-3: Do not replace IIFE with no return statement (0.297187ms)
  ✔ TN-4: Do not replace IIFE returning complex expression (0.350993ms)
  ✔ TN-5: Do not replace function expression not used as IIFE (0.373189ms)
  ✔ TN-6: Do not replace function expression without a return value (0.267767ms)
✔ SAFE: replaceFunctionShellsWithWrappedValueIIFE (6.737137ms)
▶ SAFE: replaceIdentifierWithFixedAssignedValue
  ✔ TP-1: Replace references with number literal (1.526683ms)
  ✔ TP-2: Replace references with string literal (0.878586ms)
  ✔ TP-3: Replace references with boolean literal (0.854948ms)
  ✔ TP-4: Replace multiple different variables (0.773769ms)
  ✔ TP-5: Replace with null literal (2.92594ms)
  ✔ TP-6: Replace with let declaration (1.189396ms)
  ✔ TP-7: Replace with var declaration (1.157468ms)
  ✔ TN-1: Do no replace a value used in a for-in-loop (1.214921ms)
  ✔ TN-2: Do no replace a value used in a for-of-loop (0.830121ms)
  ✔ TN-3: Do not replace variable with non-literal initializer (0.568346ms)
  ✔ TN-4: Do not replace object property names (0.573055ms)
  ✔ TN-5: Do not replace modified variables (0.706554ms)
  ✔ TN-6: Do not replace reassigned variables (0.533504ms)
  ✔ TN-7: Do not replace variable without declaration (0.37444ms)
✔ SAFE: replaceIdentifierWithFixedAssignedValue (14.856737ms)
▶ SAFE: replaceIdentifierWithFixedValueNotAssignedAtDeclaration
  ✔ TP-1: Replace identifier with number literal (2.219893ms)
  ✔ TP-2: Replace identifier with string literal (1.04045ms)
  ✔ TP-3: Replace identifier with boolean literal (1.17613ms)
  ✔ TP-4: Replace identifier with null literal (1.088473ms)
  ✔ TP-5: Replace var declaration (1.049371ms)
  ✔ TP-6: Replace with multiple references (1.051131ms)
  ✔ TN-1: Do not replace variable used in for-in loop (0.771519ms)
  ✔ TN-2: Do not replace variable used in for-of loop (0.727012ms)
  ✔ TN-3: Do not replace variable in conditional expression context (0.912317ms)
  ✔ TN-4: Do not replace variable with multiple assignments (0.572692ms)
  ✔ TN-5: Do not replace variable assigned non-literal value (0.514389ms)
  ✔ TN-6: Do not replace function callee (0.515132ms)
  ✔ TN-7: Do not replace variable with initial value (0.668601ms)
  ✔ TN-8: Do not replace when references are modified (0.631643ms)
✔ SAFE: replaceIdentifierWithFixedValueNotAssignedAtDeclaration (13.849131ms)
▶ SAFE: replaceNewFuncCallsWithLiteralContent
  ✔ TP-1: Replace Function constructor with IIFE (1.743048ms)
  ✔ TP-2: Replace Function constructor with single expression (0.623122ms)
  ✔ TP-3: Replace Function constructor with multiple statements (0.947045ms)
  ✔ TP-4: Replace Function constructor with empty string (0.442819ms)
  ✔ TP-5: Replace Function constructor with variable declaration (0.823274ms)
  ✔ TN-1: Do not replace Function constructor with arguments (0.443401ms)
  ✔ TN-2: Do not replace Function constructor with multiple parameters (0.310444ms)
  ✔ TN-3: Do not replace Function constructor with non-literal argument (0.231131ms)
  ✔ TN-4: Do not replace non-Function constructor (0.322199ms)
  ✔ TN-5: Do not replace Function constructor not used as callee (0.42926ms)
  ✔ TN-6: Do not replace Function constructor with invalid syntax (0.917625ms)
✔ SAFE: replaceNewFuncCallsWithLiteralContent (7.687624ms)
▶ SAFE: replaceBooleanExpressionsWithIf
  ✔ TP-1: Simple logical AND (1.132277ms)
  ✔ TP-2: Simple logical OR (0.63798ms)
  ✔ TP-3: Chained logical AND (0.772063ms)
  ✔ TP-4: Chained logical OR (0.579761ms)
  ✔ TP-5: Function call in condition (0.493765ms)
  ✔ TP-6: Member expression in condition (0.574135ms)
  ✔ TN-1: Do not transform non-logical expressions (0.217403ms)
  ✔ TN-2: Do not transform logical expressions not in expression statements (0.250804ms)
  ✔ TN-3: Do not transform bitwise operators (0.222716ms)
✔ SAFE: replaceBooleanExpressionsWithIf (5.346151ms)
▶ SAFE: replaceSequencesWithExpressions
  ✔ TP-1: Replace sequence with 2 expressions in if statement (0.865159ms)
  ✔ TP-2: Replace sequence with 3 expressions within existing block (0.826588ms)
  ✔ TP-3: Replace sequence in while loop (0.734691ms)
  ✔ TP-4: Replace sequence with 4 expressions (0.592721ms)
  ✔ TP-5: Replace sequence in for loop body (1.434522ms)
  ✔ TP-6: Replace sequence with mixed expression types (0.799399ms)
  ✔ TP-7: Replace sequence in else clause (0.742022ms)
  ✔ TN-1: Do not replace single expression (not a sequence) (0.272059ms)
  ✔ TN-2: Do not replace sequence with only one expression (0.203885ms)
  ✔ TN-3: Do not replace sequence in non-ExpressionStatement context (0.296011ms)
  ✔ TN-4: Do not replace sequence in return statement (0.360234ms)
  ✔ TN-5: Do not replace sequence in assignment (0.296874ms)
✔ SAFE: replaceSequencesWithExpressions (7.879703ms)
▶ SAFE: resolveDeterministicIfStatements
  ✔ TP-1: Resolve true and false literals (1.224648ms)
  ✔ TP-2: Resolve truthy number literal (0.594011ms)
  ✔ TP-3: Resolve falsy number literal (0) (0.596548ms)
  ✔ TP-4: Resolve truthy string literal (0.439113ms)
  ✔ TP-5: Resolve falsy string literal (empty) (0.502875ms)
  ✔ TP-6: Resolve null literal (0.455421ms)
  ✔ TP-7: Resolve if statement with no else clause (truthy) (0.390723ms)
  ✔ TP-8: Remove if statement with no else clause (falsy) (0.501682ms)
  ✔ TP-9: Resolve negative number literal (0.602885ms)
  ✔ TP-10: Resolve nested if statements (0.436857ms)
  ✔ TN-1: Do not resolve if with variable condition (0.294323ms)
  ✔ TN-2: Do not resolve if with function call condition (0.262107ms)
  ✔ TN-3: Do not resolve if with expression condition (0.26679ms)
  ✔ TN-4: Do not resolve if with member expression condition (0.472783ms)
✔ SAFE: resolveDeterministicIfStatements (7.55535ms)
▶ SAFE: resolveFunctionConstructorCalls
  ✔ TP-1: Replace Function.constructor with no parameters (1.505226ms)
  ✔ TP-2: Part of a member expression (3.510371ms)
  ✔ TP-3: Replace Function.constructor with single parameter (1.738659ms)
  ✔ TP-4: Replace Function.constructor with multiple parameters (1.085043ms)
  ✔ TP-5: Replace Function.constructor with complex body (1.282386ms)
  ✔ TP-6: Replace Function.constructor with empty body (0.897532ms)
  ✔ TP-7: Replace Function.constructor in variable assignment (0.881769ms)
  ✔ TP-8: Replace Function.constructor in call expression (0.845491ms)
  ✔ TN-1: Do not replace Function.constructor with non-literal arguments (0.37045ms)
  ✔ TN-2: Do not replace Function.constructor with no arguments (0.277947ms)
  ✔ TN-3: Do not replace non-constructor calls (0.252056ms)
  ✔ TN-4: Do not replace Function.constructor with invalid syntax body (0.662342ms)
  ✔ TP-9: Replace any constructor call with literal arguments (0.742544ms)
✔ SAFE: resolveFunctionConstructorCalls (14.644697ms)
▶ SAFE: resolveMemberExpressionReferencesToArrayIndex
  ✔ TP-1 (1.629361ms)
  ✔ TP-2: Replace multiple array accesses on same array (1.143308ms)
  ✔ TP-3: Replace array access with string literal elements (1.58835ms)
  ✔ TP-4: Replace array access in function call arguments (1.093751ms)
  ✔ TN-1: Don't resolve references to array methods (0.7291ms)
  ✔ TN-2: Do not resolve arrays smaller than minimum length (0.535026ms)
  ✔ TN-3: Do not resolve assignment to array elements (0.577473ms)
  ✔ TN-4: Do not resolve computed property access with variables (0.520242ms)
  ✔ TN-5: Do not resolve out-of-bounds array access (1.878015ms)
  ✔ TN-6: Do not resolve negative array indices (0.636296ms)
  ✔ TN-7: Do not resolve floating point indices (0.478125ms)
✔ SAFE: resolveMemberExpressionReferencesToArrayIndex (11.438534ms)
▶ SAFE: resolveMemberExpressionsWithDirectAssignment
  ✔ TP-1: Replace direct property assignments with literal values (1.278267ms)
  ✔ TP-2: Replace object property assignments (1.123152ms)
  ✔ TP-3: Replace computed property assignments (0.785214ms)
  ✔ TP-4: Replace boolean and null assignments (0.760894ms)
  ✔ TP-5: Replace multiple references to same property (0.65229ms)
  ✔ TN-1: Don't resolve with multiple assignments (0.29565ms)
  ✔ TN-2: Don't resolve with update expressions (0.334073ms)
  ✔ TN-3: Do not resolve when assigned non-literal value (0.329343ms)
  ✔ TN-4: Do not resolve when object has no declaration (0.25747ms)
  ✔ TN-5: Do not resolve when property is reassigned (0.404807ms)
  ✔ TN-6: Do not resolve when used in assignment expression (0.343477ms)
  ✔ TN-7: Do not resolve when property is computed with variable (0.368542ms)
  ✔ TN-8: Do not resolve when no references exist (0.2334ms)
✔ SAFE: resolveMemberExpressionsWithDirectAssignment (7.606592ms)
▶ SAFE: resolveProxyCalls
  ✔ TP-1: Replace chained proxy calls with direct function calls (1.67318ms)
  ✔ TP-2: Replace proxy with no parameters (0.850254ms)
  ✔ TP-3: Replace proxy with multiple parameters (0.950482ms)
  ✔ TP-4: Replace proxy that calls another proxy (single-step resolution) (1.019828ms)
  ✔ TN-1: Do not replace function with multiple statements (0.469272ms)
  ✔ TN-2: Do not replace function with no return statement (0.348612ms)
  ✔ TN-3: Do not replace function that returns non-call expression (0.361513ms)
  ✔ TN-4: Do not replace function that calls member expression (0.59567ms)
  ✔ TN-5: Do not replace function with parameter count mismatch (0.418316ms)
  ✔ TN-6: Do not replace function with reordered parameters (0.349034ms)
  ✔ TN-7: Do not replace function with modified parameters (0.465421ms)
  ✔ TN-8: Do not replace function with no references (0.345726ms)
✔ SAFE: resolveProxyCalls (8.419253ms)
▶ SAFE: resolveProxyReferences
  ✔ TP-1: Replace proxy reference with direct reference (1.32123ms)
  ✔ TP-2: Replace multiple proxy references to same target (0.704956ms)
  ✔ TP-3: Replace member expression proxy references (0.978593ms)
  ✔ TP-4: Replace chained proxy references (0.717159ms)
  ✔ TP-5: Replace variable with let declaration (0.730012ms)
  ✔ TP-6: Replace variable with var declaration (0.676976ms)
  ✔ TN-1: Do not replace proxy in for-in statement (0.571422ms)
  ✔ TN-2: Do not replace proxy in for-of statement (0.585458ms)
  ✔ TN-3: Do not replace proxy in for statement (0.496763ms)
  ✔ TN-4: Do not replace circular references (0.335224ms)
  ✔ TN-5: Do not replace self-referencing variables (0.240411ms)
  ✔ TN-6: Do not replace when proxy is modified (0.345267ms)
  ✔ TN-7: Do not replace when target is modified (0.310098ms)
  ✔ TN-8: Do not replace when proxy has no references (0.297944ms)
  ✔ TN-9: Do not replace non-identifier/non-member expression variables (0.241875ms)
  ✔ TP-7: Replace when target comes from function call (still safe) (0.527924ms)
✔ SAFE: resolveProxyReferences (9.64841ms)
▶ SAFE: resolveProxyVariables
  ✔ TP-1: Replace proxy variable references with target identifier (1.214381ms)
  ✔ TP-2: Remove unused proxy variable declaration (0.945253ms)
  ✔ TP-3: Replace multiple references to same proxy (0.778996ms)
  ✔ TP-4: Remove proxy variable with no references (0.433422ms)
  ✔ TP-5: Replace with let declaration (0.780871ms)
  ✔ TP-6: Replace with var declaration (0.615147ms)
  ✔ TN-1: Do not replace when proxy is assigned non-identifier (0.288975ms)
  ✔ TN-2: Do not replace when proxy is modified (0.295782ms)
  ✔ TN-3: Do not replace when proxy is updated (0.345746ms)
  ✔ TN-4: Do not replace when reference is used in assignment (0.283215ms)
  ✔ TN-5: Do not replace non-identifier initialization (0.254488ms)
✔ SAFE: resolveProxyVariables (6.645363ms)
▶ SAFE: resolveRedundantLogicalExpressions
  ✔ TP-1: Simplify basic true and false literals with && and || (0.988096ms)
  ✔ TP-2: Simplify AND expressions with truthy left operand (0.816958ms)
  ✔ TP-3: Simplify AND expressions with falsy left operand (0.647558ms)
  ✔ TP-4: Simplify AND expressions with truthy right operand (0.571795ms)
  ✔ TP-5: Simplify AND expressions with falsy right operand (0.533572ms)
  ✔ TP-6: Simplify OR expressions with truthy left operand (0.650882ms)
  ✔ TP-7: Simplify OR expressions with falsy left operand (0.583957ms)
  ✔ TP-8: Simplify OR expressions with truthy right operand (0.481776ms)
  ✔ TP-9: Simplify OR expressions with falsy right operand (0.519602ms)
  ✔ TP-10: Handle complex expressions with nested logical operators (0.477289ms)
  ✔ TN-1: Do not simplify when both operands are non-literals (0.354557ms)
  ✔ TN-2: Do not simplify non-logical expressions (0.337721ms)
  ✔ TN-3: Do not simplify logical expressions outside if statements (0.439185ms)
  ✔ TN-4: Do not simplify unsupported logical operators (if any) (0.330467ms)
✔ SAFE: resolveRedundantLogicalExpressions (8.310954ms)
▶ SAFE: unwrapFunctionShells
  ✔ TP-1: Unwrap and rename (1.315115ms)
  ✔ TP-2: Unwrap anonymous without renaming (0.675341ms)
  ✔ TP-3: Unwrap function expression assigned to variable (0.878015ms)
  ✔ TP-4: Inner function already has parameters (0.745369ms)
  ✔ TP-5: Outer function has multiple parameters (0.701552ms)
  ✔ TP-6: Complex inner function body (2.210604ms)
  ✔ TN-1: Do not unwrap function with multiple statements (0.483774ms)
  ✔ TN-2: Do not unwrap function with no return statement (0.28653ms)
  ✔ TN-3: Do not unwrap function returning .call instead of .apply (0.355915ms)
  ✔ TN-4: Do not unwrap .apply with wrong argument count (0.300447ms)
  ✔ TN-5: Do not unwrap when callee object is not FunctionExpression (0.27157ms)
  ✔ TN-6: Do not unwrap function returning non-call expression (0.291747ms)
  ✔ TN-7: Do not unwrap function with empty body (0.18884ms)
  ✔ TN-8: Do not unwrap function with BlockStatement but no statements (0.153041ms)
  ✔ TN-9: Do not unwrap arrow function as outer function (0.560909ms)
✔ SAFE: unwrapFunctionShells (9.97062ms)
▶ SAFE: unwrapIIFEs
  ✔ TP-1: Arrow functions (1.046754ms)
  ✔ TP-2: Function expressions (0.662488ms)
  ✔ TP-3: In-place unwrapping (0.684477ms)
  ✔ TN-1: Unary declarator init (0.428621ms)
  ✔ TN-2: Unary assignment right (0.491263ms)
  ✔ TP-4: IIFE with multiple statements unwrapped (0.688094ms)
  ✔ TN-3: Do not unwrap IIFE with arguments (0.331138ms)
  ✔ TN-4: Do not unwrap named function IIFE (0.371888ms)
  ✔ TN-5: Do not unwrap IIFE in assignment context (0.315407ms)
  ✔ TP-5: Arrow function IIFE with expression body (0.374734ms)
✔ SAFE: unwrapIIFEs (5.734ms)
▶ SAFE: unwrapSimpleOperations
  ✔ TP-1: Binary operations (5.989723ms)
  ✔ TP-2 Unary operations (2.538327ms)
  ✔ TP-3 Update operations (1.025488ms)
  ✔ TN-1: Do not unwrap function with multiple statements (0.484033ms)
  ✔ TN-2: Do not unwrap function with wrong parameter count (0.334737ms)
  ✔ TN-3: Do not unwrap operation not using parameters (0.493242ms)
  ✔ TN-4: Do not unwrap function with no return statement (0.390933ms)
  ✔ TN-5: Do not unwrap unsupported operator (0.338813ms)
✔ SAFE: unwrapSimpleOperations (11.942891ms)
▶ SAFE: separateChainedDeclarators
  ✔ TP-1: A single const (0.852147ms)
  ✔ TP-2: A single let (0.564537ms)
  ✔ TP-3: A var and a let (1.084154ms)
  ✔ TP-3: Wrap in a block statement for a one-liner (0.943068ms)
  ✔ TP-5: Mixed initialization patterns (0.414787ms)
  ✔ TP-6: Mixed declaration types with complex expressions (2.023353ms)
  ✔ TP-7: Three or more declarations (0.634037ms)
  ✔ TP-8: Declarations in function scope (0.71068ms)
  ✔ TN-1: Variable declarators are not chained in for statement (0.346611ms)
  ✔ TN-2: Variable declarators are not chained in for-in statement (0.329029ms)
  ✔ TN-3: Variable declarators are not chained in for-of statement (0.199047ms)
  ✔ TN-4: Single declarator should not be transformed (0.203215ms)
  ✔ TN-5: ForAwaitStatement declarations should be preserved (0.189848ms)
  ✔ TN-6: Destructuring patterns should not be separated (1.129888ms)
✔ SAFE: separateChainedDeclarators (10.252886ms)
▶ SAFE: simplifyCalls
  ✔ TP-1: With args (0.959447ms)
  ✔ TP-2: Without args (0.41233ms)
  ✔ TP-3: Mixed calls with complex arguments (0.559652ms)
  ✔ TP-4: Calls on member expressions (0.444406ms)
  ✔ TP-5: Apply with empty array (0.297802ms)
  ✔ TP-6: Call and apply in same expression (0.545433ms)
  ✔ TP-7: Call and apply with null for context (0.429157ms)
  ✔ TN-1: Ignore calls without ThisExpression (0.270931ms)
  ✔ TN-2: Do not transform Function constructor calls (0.24458ms)
  ✔ TN-3: Do not transform calls on function expressions (0.363446ms)
  ✔ TN-4: Do not transform other method names (0.273385ms)
  ✔ TN-5: Do not transform calls with this in wrong position (0.21229ms)
✔ SAFE: simplifyCalls (5.377025ms)
▶ SAFE: simplifyIfStatements
  ✔ TP-1: Empty blocks (0.653582ms)
  ✔ TP-2: Empty blocks with an empty alternate statement (0.290273ms)
  ✔ TP-3: Empty blocks with a populated alternate statement (0.441332ms)
  ✔ TP-4: Empty blocks with a populated alternate block (0.442873ms)
  ✔ TP-5: Empty statements (0.287557ms)
  ✔ TP-6: Empty statements with no alternate (0.286088ms)
  ✔ TP-7: Empty statements with an empty alternate (0.240547ms)
  ✔ TP-8: Populated consequent with empty alternate block (0.297613ms)
  ✔ TP-9: Populated consequent with empty alternate statement (0.296651ms)
  ✔ TP-10: Complex expression in test with empty branches (0.352182ms)
  ✔ TP-11: Nested empty if statements (0.402549ms)
  ✔ TN-1: Do not transform if with populated consequent and alternate (0.215555ms)
  ✔ TN-2: Do not transform if with populated block statements (0.223993ms)
  ✔ TN-3: Do not transform if with only populated consequent block (0.167612ms)
  ✔ TN-4: Do not transform complex if-else chains (0.237555ms)
✔ SAFE: simplifyIfStatements (5.36769ms)
▶ UNSAFE: normalizeRedundantNotOperator
  ✔ TP-1: Mixed literals and expressions (30.70787ms)
  ✔ TP-2: String literals (6.213009ms)
  ✔ TP-3: Number literals (6.212958ms)
  ✔ TP-4: Null literal (4.661015ms)
  ✔ TP-5: Empty array and object literals (5.602853ms)
  ✔ TP-6: Simple nested NOT operations (5.095668ms)
  ✔ TP-7: Normalize complex literals that can be safely evaluated (7.39194ms)
  ✔ TN-1: Do not normalize NOT on variables (1.569205ms)
  ✔ TN-2: Do not normalize NOT on complex expressions (2.840391ms)
  ✔ TN-3: Do not normalize NOT on function calls (1.411372ms)
  ✔ TN-4: Do not normalize NOT on computed properties (0.932288ms)
  ✔ TN-5: Do not normalize literals with unpredictable values (0.51618ms)
✔ UNSAFE: normalizeRedundantNotOperator (76.885402ms)
▶ UNSAFE: resolveAugmentedFunctionWrappedArrayReplacements
  ✔ Add Missing True Positive Test Cases (0.315966ms) # TODO
  ✔ TN-1: Do not transform functions without augmentation (6.340854ms)
  ✔ TN-2: Do not transform functions without array operations (2.875393ms)
  ✔ TN-3: Do not transform when no matching expression statements (2.165153ms)
  ✔ TN-4: Do not transform anonymous functions (0.898506ms)
  ✔ TN-5: Do not transform when array candidate has no declNode (0.827009ms)
  ✔ TN-6: Do not transform when expression statement pattern is wrong (3.411808ms)
  ✔ TN-7: Do not transform when no replacement candidates found (2.334893ms)
✔ UNSAFE: resolveAugmentedFunctionWrappedArrayReplacements (19.871973ms)
▶ UNSAFE: resolveBuiltinCalls
  ✔ TP-1: atob (6.407683ms)
  ✔ TP-2: btoa (5.737071ms)
  ✔ TP-3: split (6.70909ms)
  ✔ TP-4: Member expression with literal arguments (5.251742ms)
  ✔ TP-5: Multiple builtin calls (4.694716ms)
  ✔ TP-6: String method with multiple arguments (6.172095ms)
  ✔ TN-1: querySelector (0.534574ms)
  ✔ TN-2: Unknown variable (5.543832ms)
  ✔ TN-3: Overwritten builtin (0.914386ms)
  ✔ TN-4: Skip builtin function call (0.49066ms)
  ✔ TN-5: Skip member expression with restricted property (0.433413ms)
  ✔ TN-6: Function call with this expression (0.83515ms)
  ✔ TN-7: Constructor property access (0.655032ms)
  ✔ TN-8: Member expression with computed property using variable (6.444955ms)
✔ UNSAFE: resolveBuiltinCalls (52.426222ms)
▶ UNSAFE: resolveDefiniteBinaryExpressions
  ✔ TP-1: Mixed arithmetic and string operations (8.279159ms)
  ✔ TP-2: Division and modulo operations (6.483384ms)
  ✔ TP-3: Bitwise operations (6.077358ms)
  ✔ TP-4: Comparison operations (5.484137ms)
  ✔ TP-5: Negative number edge case handling (6.356685ms)
  ✔ TP-6: Null operations and string concatenation (5.685575ms)
  ✔ TN-1: Do not resolve expressions with variables (0.529661ms)
  ✔ TN-2: Do not resolve expressions with function calls (0.541446ms)
  ✔ TN-3: Do not resolve member expressions (0.696838ms)
  ✔ TN-4: Do not resolve complex nested expressions (1.577878ms)
  ✔ TN-5: Do not resolve logical expressions (not BinaryExpressions) (0.539962ms)
  ✔ TN-6: Do not resolve expressions with undefined identifier (0.460571ms)
  ✔ Helper TP-1: Literal node (0.477129ms)
  ✔ Helper TP-2: Binary expression with literals (0.596296ms)
  ✔ Helper TP-3: Unary expression with literal (0.351017ms)
  ✔ Helper TP-4: Complex nested binary expressions (0.47162ms)
  ✔ Helper TP-5: Logical expression with literals (0.375704ms)
  ✔ Helper TP-6: Conditional expression with literals (0.668732ms)
  ✔ Helper TP-7: Sequence expression with literals (1.469927ms)
  ✔ Helper TN-7: Update expression with identifier (1.046338ms)
  ✔ Helper TN-1: Identifier is rejected (0.400677ms)
  ✔ Helper TN-2: Unary expression with identifier (0.414135ms)
  ✔ Helper TN-3: Binary expression with identifier (0.419614ms)
  ✔ Helper TN-4: Complex non-literal expressions are rejected (0.40147ms)
  ✔ Helper TN-5: Function calls and member expressions (0.607458ms)
  ✔ Helper TN-6: Null and undefined handling (0.161313ms)
✔ UNSAFE: resolveDefiniteBinaryExpressions (52.629559ms)
▶ UNSAFE: resolveDefiniteMemberExpressions
  ✔ TP-1: String and array indexing with properties (6.051248ms)
  ✔ TP-2: Array literal indexing (5.973972ms)
  ✔ TP-3: String indexing with different positions (4.185374ms)
  ✔ TP-4: Array length property (3.82842ms)
  ✔ TP-5: Mixed literal types in arrays (3.882218ms)
  ✔ TP-6: Non-computed property access with identifier (3.726285ms)
  ✔ TN-1: Do not transform update expressions (0.344891ms)
  ✔ TN-2: Do not transform method calls (callee position) (2.647151ms)
  ✔ TN-3: Do not transform computed properties with variables (0.547484ms)
  ✔ TN-4: Do not transform non-literal objects (0.337711ms)
  ✔ TN-5: Do not transform empty literals (0.283742ms)
  ✔ TN-6: Do not transform complex property expressions (0.321418ms)
  ✔ TN-7: Do not transform out-of-bounds access (handled by sandbox) (2.853295ms)
✔ UNSAFE: resolveDefiniteMemberExpressions (35.795285ms)
▶ UNSAFE: resolveDeterministicConditionalExpressions
  ✔ TP-1: Boolean literals (true/false) (3.390667ms)
  ✔ TP-2: Truthy string literals (3.134879ms)
  ✔ TP-3: Falsy string literal (empty string) (3.134606ms)
  ✔ TP-4: Truthy number literals (3.388879ms)
  ✔ TP-5: Falsy number literal (zero) (3.135636ms)
  ✔ TP-6: Null literal (3.048731ms)
  ✔ TP-7: Nested conditional expressions (single pass) (3.165707ms)
  ✔ TP-8: Complex expressions as branches (3.618976ms)
  ✔ TN-1: Non-literal test expressions (0.551009ms)
  ✔ TN-2: Variable test expressions (0.360745ms)
  ✔ TN-3: Function call test expressions (0.359262ms)
  ✔ TN-4: Binary expression test expressions (0.318281ms)
  ✔ TN-5: Member expression test expressions (0.295429ms)
  ✔ TN-6: Unary expressions (not literals) (0.273649ms)
  ✔ TN-7: Undefined identifier (not literal) (0.202637ms)
✔ UNSAFE: resolveDeterministicConditionalExpressions (29.012765ms)
▶ UNSAFE: resolveEvalCallsOnNonLiterals
  ✔ TP-1: Function call that returns string (5.26797ms)
  ✔ TP-2: Array access returning empty string (3.553253ms)
  ✔ TP-3: Variable reference resolution (4.03998ms)
  ✔ TP-4: Function expression IIFE (4.088181ms)
  ✔ TP-5: Member expression property access (4.499252ms)
  ✔ TP-6: Array index with complex expression (4.55843ms)
  ✔ TN-1: Eval with literal string (already handled by another module) (0.347192ms)
  ✔ TN-2: Non-eval function calls (0.340256ms)
  ✔ TN-3: Eval with multiple arguments (0.363878ms)
  ✔ TN-4: Eval with no arguments (0.364721ms)
  ✔ TN-5: Computed member expression for eval (0.39256ms)
  ✔ TN-6: Eval with non-evaluable expression (3.092083ms)
✔ UNSAFE: resolveEvalCallsOnNonLiterals (31.48455ms)
▶ UNSAFE: resolveFunctionToArray
  ✔ TP-1: Simple function returning array (5.282136ms)
  ✔ TP-2: Function with multiple elements (4.409379ms)
  ✔ TP-3: Arrow function returning array (5.804055ms)
  ✔ TP-4: Function with parameters (ignored) (5.520554ms)
  ✔ TP-5: Multiple variables with array access only (5.850131ms)
  ✔ TN-1: Function call with non-array-access usage (0.930077ms)
  ✔ TP-6: Variable with empty references array (should transform) (5.782385ms)
  ✔ TN-3: Variable not assigned function call (0.897083ms)
  ✔ TN-4: Mixed usage (array access and other) (1.092081ms)
  ✔ TP-7: Function with property access (length is MemberExpression) (5.140901ms)
  ✔ TN-5: Function with method calls (not just property access) (0.646702ms)
  ✔ TN-6: Non-literal init expression (3.968637ms)
✔ UNSAFE: resolveFunctionToArray (46.204601ms)
▶ UNSAFE: resolveInjectedPrototypeMethodCalls
  ✔ TP-1: String prototype method injection (11.622407ms)
  ✔ TP-2: Number prototype method injection (3.914022ms)
  ✔ TP-3: Array prototype method injection (3.627012ms)
  ✔ TP-4: Method with parameters (3.923364ms)
  ✔ TP-5: Multiple calls to same injected method (4.008099ms)
  ✔ TP-6: Identifier assignment to prototype method (3.799108ms)
  ✔ TP-7: Method call with missing arguments resolves to expected result (3.721927ms)
  ✔ TP-8: Arrow function prototype method injection (3.737739ms)
  ✔ TP-9: Arrow function with parameters (3.666065ms)
  ✔ TP-10: Arrow function using closure variable (3.501224ms)
  ✔ TN-1: Non-prototype property assignment (0.540557ms)
  ✔ TN-2: Non-function assignment to prototype (0.515348ms)
  ✔ TN-3: Call to non-injected method (3.048846ms)
  ✔ TN-4: Assignment with non-assignment operator (0.669434ms)
  ✔ TN-5: Complex expression assignment to prototype (0.426561ms)
  ✔ TN-6: Arrow function returning this (may not evaluate safely) (3.469606ms)
✔ UNSAFE: resolveInjectedPrototypeMethodCalls (55.109157ms)
▶ UNSAFE: resolveLocalCalls
  ✔ TP-1: Function declaration (4.646589ms)
  ✔ TP-2: Arrow function (3.872464ms)
  ✔ TP-3: Overwritten builtin (3.645758ms)
  ✔ TP-4: Function expression (4.11267ms)
  ✔ TP-5: Multiple calls to same function (4.115001ms)
  ✔ TP-6: Function returning string (3.797121ms)
  ✔ TN-1: Missing declaration (0.388367ms)
  ✔ TN-2: Skipped builtin (0.228149ms)
  ✔ TN-3: No replacement with undefined (3.336661ms)
  ✔ TN-4: Complex member expression property access (3.485307ms)
  ✔ TP-7: Function call argument with FunctionExpression (6.922516ms)
  ✔ TN-5: Function toString (anti-debugging protection) (0.427253ms)
  ✔ TN-6: Simple wrapper function (handled by safe modules) (0.298382ms)
  ✔ TN-7: Call with ThisExpression argument (0.332706ms)
  ✔ TN-8: Member expression call on empty array (4.008579ms)
✔ UNSAFE: resolveLocalCalls (44.392607ms)
▶ UNSAFE: resolveMinimalAlphabet
  ✔ TP-1: Unary expressions on literals and arrays (34.423855ms)
  ✔ TP-2: Binary expressions with arrays (JSFuck patterns) (10.197594ms)
  ✔ TP-3: Unary expressions on null literal (7.802473ms)
  ✔ TP-4: Binary expressions with string concatenation (7.512229ms)
  ✔ TN-1: Expressions containing ThisExpression should be skipped (10.61728ms)
  ✔ TN-2: Binary expressions with non-plus operators (0.365129ms)
  ✔ TN-3: Unary expressions on numeric literals (0.292418ms)
  ✔ TN-4: Unary expressions on undefined identifier (0.247403ms)
✔ UNSAFE: resolveMinimalAlphabet (71.867702ms)
▶ resolveMemberExpressionsLocalReferences (resolveMemberExpressionsLocalReferences.js)
  ✔ TP-1: Array index access with literal (3.571502ms)
  ✔ TP-2: Object property access with dot notation (3.437888ms)
  ✔ TP-3: Object property access with string literal (3.622945ms)
  ✔ TP-4: Constructor property access (3.545691ms)
  ✔ TN-1: Object computed property with identifier variable (3.367179ms)
  ✔ TN-2: Array index with identifier variable (3.186143ms)
  ✔ TN-3: Function parameter reference (3.506313ms)
  ✔ TN-4: Member expression on left side of assignment (0.486092ms)
  ✔ TN-5: Member expression used as call expression callee (0.533394ms)
  ✔ TN-6: Property with skipped name (length) (0.353383ms)
✔ resolveMemberExpressionsLocalReferences (resolveMemberExpressionsLocalReferences.js) (26.089435ms)
▶ UTILS: evalInVm
  ✔ TP-1: String concatenation (7.999535ms)
  ✔ TP-2: Arithmetic operations (4.456321ms)
  ✔ TP-3: Array literal evaluation (4.461737ms)
  ✔ TP-4: Object literal evaluation (4.913971ms)
  ✔ TP-5: Boolean operations (4.682103ms)
  ✔ TP-6: Array length property (4.683497ms)
  ✔ TP-7: String method calls (4.726177ms)
  ✔ TP-8: Caching behavior - identical code returns same result (5.093231ms)
  ✔ TP-9: Sandbox reuse (3.771175ms)
  ✔ TP-10: Multi-statement code with valid operations (3.546421ms)
  ✔ TP-11: Trap neutralization - infinite while loop (3.046884ms)
  ✔ TP-12: Complex expression evaluation (3.188461ms)
  ✔ TP-14: Debugger statement (neutralized and evaluates successfully) (4.383947ms)
  ✔ TP-13: Split debugger string neutralization works (3.062612ms)
  ✔ TN-1: Non-deterministic function calls (3.305296ms)
  ✔ TN-2: Console object evaluation (3.273435ms)
  ✔ TN-3: Promise objects (bad type) (3.204263ms)
  ✔ TN-4: Invalid syntax (3.144068ms)
  ✔ TN-5: Function calls with side effects (3.12337ms)
  ✔ TN-6: Variable references (undefined) (4.864084ms)
  ✔ TN-7: Complex expressions with timing dependencies (3.375725ms)
✔ UTILS: evalInVm (89.69942ms)
▶ UTILS: areReferencesModified
  ✔ TP-1: Update expression (11.972221ms)
  ✔ TP-2: Direct assignment (3.119779ms)
  ✔ TP-3: Assignment to property (2.311052ms)
  ✔ TP-4: Re-assignment to property (0.95612ms)
  ✔ TP-5: Delete operation on object property (1.062221ms)
  ✔ TP-6: Delete operation on array element (0.741335ms)
  ✔ TP-7: For-in loop variable modification (1.346783ms)
  ✔ TP-8: For-of loop variable modification (0.718467ms)
  ✔ TP-9: Array mutating method call (0.964388ms)
  ✔ TP-10: Array sort method call (0.666211ms)
  ✔ TP-11: Object destructuring assignment (0.901255ms)
  ✔ TP-12: Array destructuring assignment (0.590235ms)
  ✔ TP-13: Update expression on member expression (0.467546ms)
  ✔ TN-1: No assignment (0.540308ms)
  ✔ TN-2: Read-only property access (0.558739ms)
  ✔ TN-3: Read-only array access (0.700664ms)
  ✔ TN-4: Non-mutating method calls (0.487165ms)
  ✔ TN-5: For-in loop with different variable (0.871343ms)
  ✔ TN-6: Safe destructuring (different variable) (0.599859ms)
✔ UTILS: areReferencesModified (30.432608ms)
▶ UTILS: createNewNode
  ✔ Literan: String (0.303381ms)
  ✔ Literan: String that starts with ! (0.131112ms)
  ✔ Literal: Number - positive number (0.081041ms)
  ✔ Literal: Number - negative number (0.114086ms)
  ✔ Literal: Number - negative infinity (0.093874ms)
  ✔ Literal: Number - negative zero (0.078744ms)
  ✔ Literal: Number - NOT operator (0.070299ms)
  ✔ Literal: Number - Identifier (0.088912ms)
  ✔ Literal: Boolean (0.069376ms)
  ✔ Array: empty (0.139199ms)
  ✔ Array: populated (0.191863ms)
  ✔ Object: empty (0.092183ms)
  ✔ Object: populated (0.253149ms)
  ✔ Object: populated with BAD_VALUE (0.801305ms)
  ✔ Undefined (0.117962ms)
  ✔ Null (0.085112ms)
  ✔ TODO: Implement Function (0.057713ms) # TODO
  ✔ RegExp (0.12541ms)
  ✔ BigInt (0.116984ms)
  ✔ Symbol with description (0.134853ms)
  ✔ Symbol without description (0.28545ms)
✔ UTILS: createNewNode (4.060351ms)
▶ UTILS: doesDescendantMatchCondition
  ✔ TP-1: Find descendant by type (boolean return) (2.988094ms)
  ✔ TP-2: Find descendant by type (node return) (0.807875ms)
  ✔ TP-3: Find marked descendant (simulating isMarked property) (0.667112ms)
  ✔ TP-4: Multiple nested descendants (0.881285ms)
  ✔ TP-5: Find specific assignment pattern (0.826112ms)
  ✔ TN-1: No matching descendants (0.562671ms)
  ✔ TN-2: Node itself matches condition (0.431099ms)
  ✔ TN-3: Null/undefined input handling (0.228658ms)
  ✔ TN-4: Node with no children (0.500463ms)
  ✔ TN-5: Empty childNodes array (0.152496ms)
✔ UTILS: doesDescendantMatchCondition (8.661879ms)
▶ UTILS: generateHash
  ✔ TP-1: Generate hash for normal string (0.386385ms)
  ✔ TP-2: Generate hash for AST node with .src property (0.294185ms)
  ✔ TP-3: Generate hash for number input (0.118111ms)
  ✔ TP-4: Generate hash for boolean input (0.080706ms)
  ✔ TP-5: Generate hash for empty string (0.072799ms)
  ✔ TP-6: Consistent hashes for identical inputs (0.072562ms)
  ✔ TP-7: Different hashes for different inputs (0.117249ms)
  ✔ TN-1: Handle null input gracefully (0.063437ms)
  ✔ TN-2: Handle undefined input gracefully (0.054912ms)
  ✔ TN-3: Handle object without .src property (0.1054ms)
✔ UTILS: generateHash (1.634787ms)
▶ UTILS: createOrderedSrc
  ✔ TP-1: Re-order nodes (0.744045ms)
  ✔ TP-2: Wrap calls in expressions (0.417346ms)
  ✔ TP-3: Push IIFEs to the end in order (0.978538ms)
  ✔ TP-4: Add dynamic name to IIFEs (5.450746ms)
  ✔ TP-5: Add variable name to IIFEs (1.431907ms)
  ✔ TP-6: Preserve node order (0.664269ms)
  ✔ TP-7: Standalone FEs (0.629913ms)
  ✔ TP-8: Variable declarations with semicolons (0.379321ms)
  ✔ TP-9: Assignment expressions with semicolons (0.464365ms)
  ✔ TP-10: Duplicate node elimination (0.46114ms)
  ✔ TP-11: IIFE dependency ordering with arguments (0.573537ms)
  ✔ TN-1: Empty node array (0.089138ms)
  ✔ TN-2: Single node without reordering (0.24967ms)
  ✔ TN-3: Non-CallExpression and non-FunctionExpression nodes (0.331881ms)
  ✔ TN-4: CallExpression without ExpressionStatement parent (0.281932ms)
  ✔ TN-5: Named function expressions (no renaming needed) (0.465716ms)
✔ UTILS: createOrderedSrc (14.18926ms)
▶ UTILS: getCache
  ✔ TP-1: Retain values for same script hash (0.42365ms)
  ✔ TP-2: Cache invalidation on script hash change (0.124813ms)
  ✔ TP-3: Manual flush preserves script hash (0.12106ms)
  ✔ TP-4: Multiple script hash switches (0.189306ms)
  ✔ TP-5: Cache object mutation persistence (0.109817ms)
  ✔ TN-1: Handle null script hash gracefully (0.107031ms)
  ✔ TN-2: Handle undefined script hash gracefully (0.096626ms)
  ✔ TN-3: Null and undefined should share same fallback cache (0.183982ms)
  ✔ TN-4: Empty string script hash (0.117897ms)
  ✔ TN-5: Flush after multiple hash changes (0.124834ms)
✔ UTILS: getCache (1.856955ms)
▶ UTILS: getCalleeName
  ✔ TP-1: Simple identifier callee (0.494878ms)
  ✔ TP-2: Member expression callee (single level) (0.34711ms)
  ✔ TP-3: Nested member expression callee (0.385193ms)
  ✔ TP-4: Deeply nested member expression (0.266497ms)
  ✔ TP-5: Avoid counting collision between function and literal calls (0.489575ms)
  ✔ TN-1: Literal string method calls return empty (0.242154ms)
  ✔ TN-2: Literal number method calls return empty (0.22784ms)
  ✔ TN-3: ThisExpression method calls return empty (0.260216ms)
  ✔ TN-4: Boolean literal method calls return empty (0.223537ms)
  ✔ TN-5: Logical expression callee returns empty (0.514593ms)
  ✔ TN-6: CallExpression as base object returns empty (0.414949ms)
  ✔ TN-7: Null/undefined input handling (0.111765ms)
  ✔ TN-8: Computed member expression with identifier (0.351491ms)
  ✔ TN-9: Complex callee without name returns empty (0.088032ms)
✔ UTILS: getCalleeName (4.809636ms)
▶ UTILS: getDeclarationWithContext
  ✔ TP-1: Call expression with function declaration (1.177919ms)
  ✔ TP-2: Call expression with function expression (0.922158ms)
  ✔ TP-3: Nested call with FE (0.645196ms)
  ✔ TP-4: Anti-debugging function overwrite (0.962221ms)
  ✔ TP-5: Collect assignments on references (0.834658ms)
  ✔ TP-6: Collect relevant parents for anonymous FE (0.468595ms)
  ✔ TP-7: Node without scriptHash should still work (0.73232ms)
  ✔ TP-8: Node without nodeId should still work (0.479386ms)
  ✔ TN-1: Prevent collection before changes are applied (0.784755ms)
  ✔ TN-2: Handle null input gracefully (0.147568ms)
  ✔ TN-3: Handle undefined input gracefully (0.096955ms)
✔ UTILS: getDeclarationWithContext (7.664449ms)
▶ UTILS: getDescendants
  ✔ TP-1 (0.531612ms)
  ✔ TP-2: Limited scope (0.372295ms)
  ✔ TP-3: Nested function with complex descendants (0.679397ms)
  ✔ TP-4: Object expression with properties (0.459411ms)
  ✔ TP-5: Array expression with elements (0.51304ms)
  ✔ TP-6: Caching behavior - same node returns cached result (0.278693ms)
  ✔ TN-1: No descendants for leaf nodes (0.310859ms)
  ✔ TN-2: Null input returns empty array (0.087543ms)
  ✔ TN-3: Undefined input returns empty array (0.061647ms)
  ✔ TN-4: Node with no childNodes property (0.088109ms)
  ✔ TN-5: Node with empty childNodes array (0.074693ms)
✔ UTILS: getDescendants (3.788614ms)
▶ UTILS: getMainDeclaredObjectOfMemberExpression
  ✔ TP-1: Simple member expression with declared object (0.408541ms)
  ✔ TP-2: Nested member expression finds root identifier (0.46893ms)
  ✔ TP-3: Computed member expression with declared base (0.344564ms)
  ✔ TP-4: Deep nesting finds correct root (0.296429ms)
  ✔ TN-1: Non-MemberExpression input returns the input unchanged (0.271965ms)
  ✔ TN-2: Null input returns null (0.077656ms)
  ✔ TN-3: Undefined input returns null (0.064927ms)
  ✔ TN-4: Member expression with no declNode still returns the object (0.238692ms)
  ✔ TN-5: Non-MemberExpression with declNode returns itself (0.266454ms)
✔ UTILS: getMainDeclaredObjectOfMemberExpression (2.988707ms)
▶ UTILS: getObjType
  ✔ TP-1: Detect Array type (0.178514ms)
  ✔ TP-2: Detect Object type (0.091129ms)
  ✔ TP-3: Detect String type (0.094633ms)
  ✔ TP-4: Detect Number type (0.059459ms)
  ✔ TP-5: Detect Boolean type (0.054217ms)
  ✔ TP-6: Detect Null type (0.049272ms)
  ✔ TP-7: Detect Undefined type (0.053644ms)
  ✔ TP-8: Detect Date type (0.059164ms)
  ✔ TP-9: Detect RegExp type (0.059329ms)
  ✔ TP-10: Detect Function type (0.066633ms)
  ✔ TP-11: Detect Arrow Function type (0.051336ms)
  ✔ TP-12: Detect Error type (0.068803ms)
  ✔ TP-13: Detect empty array (0.057892ms)
  ✔ TP-14: Detect empty object (0.054123ms)
  ✔ TP-15: Detect Symbol type (0.110399ms)
  ✔ TP-16: Detect BigInt type (0.059565ms)
✔ UTILS: getObjType (1.466435ms)
▶ UTILS: isNodeInRanges
  ✔ TP-1: Node completely within single range (2.131539ms)
  ✔ TP-2: Node within multiple ranges (first match) (0.616031ms)
  ✔ TP-3: Node within multiple ranges (second match) (0.476187ms)
  ✔ TP-4: Node exactly matching range boundaries (0.451069ms)
  ✔ TP-5: Large range containing small node (0.61453ms)
  ✔ TN-1: Node extends beyond range end (0.391039ms)
  ✔ TN-2: Node starts before range start (0.388109ms)
  ✔ TN-3: Empty ranges array (0.563702ms)
  ✔ TN-4: Node range partially overlapping but not contained (0.47204ms)
✔ UTILS: isNodeInRanges (6.562168ms)
▶ UTILS: Sandbox
  ✔ TP-1: Basic code execution (3.782432ms)
  ✔ TP-2: String operations (5.206581ms)
  ✔ TP-3: Array operations (3.363091ms)
  ✔ TP-4: Object operations (3.381218ms)
  ✔ TP-5: Multiple executions on same sandbox (3.481675ms)
  ✔ TP-6: Deterministic behavior - Math.random is deleted (2.364309ms)
  ✔ TP-7: Deterministic behavior - Date is deleted (2.508209ms)
  ✔ TP-8: Blocked API - WebAssembly is undefined (2.571947ms)
  ✔ TP-9: Blocked API - fetch is undefined (2.52041ms)
  ✔ TP-10: isReference method correctly identifies VM References (2.726622ms)
  ✔ TN-1: isReference returns false for null (2.426156ms)
  ✔ TN-2: isReference returns false for undefined (2.728934ms)
  ✔ TN-3: isReference returns false for regular objects (2.707633ms)
✔ UTILS: Sandbox (40.581475ms)
▶ Processors tests: Augmented Array
  ✔ TP-1: Complex IIFE with mixed array elements (23.566655ms)
  ✔ TP-2: Simple array with single shift (6.834798ms)
  ✔ TP-3: Array with zero shifts (no change) (5.752627ms)
  ✔ TP-4: Array with larger shift count (5.11896ms)
  ✔ TN-1: IIFE with non-literal shift count (1.862119ms)
  ✔ TN-2: IIFE with insufficient arguments (1.606508ms)
  ✔ TN-3: IIFE with non-identifier array argument (1.556204ms)
  ✔ TN-4: Non-IIFE function call (1.749905ms)
  ✔ TN-5: Invalid shift count (NaN) (1.210275ms)
  ✔ TN-9: Function passed to IIFE (function not self-modifying) (1.743363ms)
  ✔ TP-5: Arrow function IIFE (5.097799ms)
  ✔ TP-6: Shift count larger than array length (4.463108ms)
  ✔ TN-10: Arrow function without parentheses around parameters (0.673431ms)
  ✔ TN-11: Negative shift count (0.789689ms)
  ✔ TN-12: IIFE with complex array manipulation that cannot be resolved (4.274135ms)
✔ Processors tests: Augmented Array (69.14692ms)
▶ Processors tests: Caesar Plus
  ﹣ TP-1: FIX ME (0.098309ms) # SKIP
✔ Processors tests: Caesar Plus (0.254539ms)
▶ Processors tests: Function to Array
  ✔ TP-1: Independent call (6.048333ms)
  ✔ TP-2: IIFE (5.400381ms)
  ✔ TP-3: Arrow function returning array (5.22681ms)
  ✔ TP-4: Multiple variables with array access only (7.248157ms)
  ✔ TN-1: Function called multiple times without assignment (0.693179ms)
  ✔ TN-2: Mixed usage (array access and other) (0.647166ms)
  ✔ TN-3: Variable not assigned function call (0.456621ms)
✔ Processors tests: Function to Array (26.08568ms)
▶ Processors tests: Obfuscator.io
  ✔ TP-1 (2.076798ms)
  ✔ TP-2 (1.299336ms)
✔ Processors tests: Obfuscator.io (3.525222ms)
▶ Samples tests
  ✔ Deobfuscate sample: JSFuck (330.912881ms)
  ✔ Deobfuscate sample: Ant & Cockroach (338.274269ms)
  ✔ Deobfuscate sample: New Function IIFE (179.490168ms)
  ✔ Deobfuscate sample: Hunter (363.643145ms)
  ✔ Deobfuscate sample: _$_ (423.673203ms)
  ✔ Deobfuscate sample: Prototype Calls (642.304473ms)
  ﹣ TODO: FIX Deobfuscate sample: Caesar+ (0.153182ms) # SKIP
  ✔ Deobfuscate sample: eval(Ox$ (1703.377956ms)
  ✔ Deobfuscate sample: Obfuscator.io (5621.399193ms)
  ✔ Deobfuscate sample: $s (7586.357786ms)
  ✔ Deobfuscate sample: Local Proxies (9680.93158ms)
✔ Samples tests (26874.610494ms)
▶ parseArgs tests
  ✔ TP-1: Defaults (8.664268ms)
  ✔ TP-2: All on - short (2.270789ms)
  ✔ TP-3: All on - full (1.016509ms)
  ✔ TP-4: Custom outputFilename split (0.78893ms)
  ✔ TP-5: Custom outputFilename equals (0.579271ms)
  ✔ TP-6: Custom outputFilename full (0.636346ms)
  ✔ TP-7: Max iterations short equals (0.636818ms)
  ✔ TP-8: Max iterations short split (0.868864ms)
  ✔ TP-9: Max iterations long equals (1.441521ms)
  ✔ TP-10: Max iterations long split (1.201589ms)
✔ parseArgs tests (21.914664ms)
ℹ tests 763
ℹ suites 64
ℹ pass 757
ℹ fail 0
ℹ cancelled 0
ℹ skipped 4
ℹ todo 2
ℹ duration_ms 27916.526906


</details>